### PR TITLE
Conflict between PAUSE and M600

### DIFF
--- a/files/macros/M600-support.cfg
+++ b/files/macros/M600-support.cfg
@@ -39,6 +39,7 @@ gcode:
   {action_respond_info("z_safe = %s"% (z_safe))}
   SET_GCODE_VARIABLE MACRO=M600 VARIABLE=m600_state VALUE=1
   SET_GCODE_VARIABLE MACRO=PRINTER_PARAM VARIABLE=hotend_temp VALUE={printer.extruder.target}
+  SET_GCODE_VARIABLE MACRO=PRINTER_PARAM VARIABLE=z_safe_pause VALUE={z_safe|float}
   RESPOND TYPE=command MSG="Print paused for filament change!"
   PAUSE_BASE
   G91
@@ -90,13 +91,6 @@ gcode:
   {% if printer['gcode_macro PRINTER_PARAM'].fan2_speed > 0 %}
     {% set s_value = (printer['gcode_macro PRINTER_PARAM'].fan2_speed * 255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) * 255 / (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min)|float %}
     M106 P2 S{s_value}
-  {% endif %}
-  {% set z_resume_move = printer['gcode_macro PRINTER_PARAM'].z_safe_pause|int %}
-  {% if z_resume_move > 2 %}
-    {% set z_resume_move = z_resume_move - 2 %}
-    G91
-    G1 Z-{z_resume_move} F600
-    M400
   {% endif %}
   {% set E = printer["gcode_macro PAUSE"].extrude|float + 1.0 %}
   {% if 'VELOCITY' in params|upper %}

--- a/files/macros/M600-support.cfg
+++ b/files/macros/M600-support.cfg
@@ -92,6 +92,15 @@ gcode:
     {% set s_value = (printer['gcode_macro PRINTER_PARAM'].fan2_speed * 255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) * 255 / (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min)|float %}
     M106 P2 S{s_value}
   {% endif %}
+  {% if printer['gcode_macro M600'].m600_state != 1 %}
+    {% set z_resume_move = printer['gcode_macro PRINTER_PARAM'].z_safe_pause|int %}
+    {% if z_resume_move > 2 %}
+      {% set z_resume_move = z_resume_move - 2 %}
+      G91
+      G1 Z-{z_resume_move} F600
+      M400
+    {% endif %}
+  {% endif %}
   {% set E = printer["gcode_macro PAUSE"].extrude|float + 1.0 %}
   {% if 'VELOCITY' in params|upper %}
     {% set get_params = ('VELOCITY=' + params.VELOCITY) %}


### PR DESCRIPTION
I noticed that if I'm using just a multicolor print itself, everything is fine.

But recently I was in need of a `PAUSE` on a certain layers and I discovered a buggy behaviour: before extruding a new filament Z axis moves to the last safe position and only then extruder starts purging a new filament. 

Let's consider the following scenario:
1. `PAUSE` is used on a 5th layer
2. `M600` is used on a 10th layer

In such a case, `PAUSE` macro [writes `z_safe_pause`position](https://github.com/Guilouz/Creality-K1-Extracted-Firmwares/blob/210827331fdd1ad7987971a8be9e5ee6aa0ef79f/Firmware/usr/share/klipper/config/K1_CR4CU220812S10/gcode_macro.cfg#L308).

Now `M600` on a 10th layer works fine, but `RESUME` doesn't. `RESUME` reads the last `z_safe_pause` written by `PAUSE` on 5th layer and since it's defined it tries to perform a Z movement to the 5th (?) layer (not sure 5th or 10th actually, but it moves - that's the fact).

And when the nozzle is 1cm above the heating bed it starts exrtuding tons of filament that doesn't fit into such a small gap.

This happens only when a `PAUSE` macro (not `M600`) was used before `M600`.

In attempts to debug this I found that the issue is caused by:
1. `M600` macro not updating `z_safe_pause` position like a regular `PAUSE` does
2. `RESUME` probably shouldn't contain those `Z` movement before extruding at all

Extrusion should always happen from the distance to have enough space for a waste.