### PR TITLE
fixes process not killed on remove

### DIFF
--- a/scripts/git_backup.sh
+++ b/scripts/git_backup.sh
@@ -60,6 +60,8 @@ function remove_git_backup(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        echo -e "Info: Stopping processes..."
+        pkill git-backup.sh
         echo -e "Info: Removing files..."
         rm -f "$HS_CONFIG_FOLDER"/git-backup.cfg
         rm -f "INITD_FOLDER"/S52Git-Backup

--- a/scripts/git_backup.sh
+++ b/scripts/git_backup.sh
@@ -64,7 +64,7 @@ function remove_git_backup(){
         pkill git-backup.sh
         echo -e "Info: Removing files..."
         rm -f "$HS_CONFIG_FOLDER"/git-backup.cfg
-        rm -f "INITD_FOLDER"/S52Git-Backup
+        rm -f "$INITD_FOLDER"/S52Git-Backup
         rm -rf "$PRINTER_DATA_FOLDER"/.git
         if grep -q "include Helper-Script/git-backup" "$PRINTER_CFG" ; then
           echo -e "Info: Removing Git Backup configurations in printer.cfg file..."


### PR DESCRIPTION
When removing git-backup using the installer, there are still some processes left running in the background. To ensure a clean removal, and prevent problems on reinstallation, these processes should be killed on removal.