### PR TITLE
Reload camera config

### DIFF
--- a/files/macros/useful-macros.cfg
+++ b/files/macros/useful-macros.cfg
@@ -22,6 +22,11 @@ command: sh /usr/data/helper-script/files/scripts/useful_macros.sh -restore_moon
 timeout: 600.0
 verbose: true
 
+[gcode_shell_command Reload_Camera]
+command: sh /usr/data/helper-script/files/scripts/useful_macros.sh -reload_camera
+timeout: 600.0
+verbose: true
+
 
 [gcode_macro KLIPPER_BACKUP_CONFIG]
 gcode:
@@ -41,6 +46,10 @@ gcode:
 [gcode_macro MOONRAKER_RESTORE_DATABASE]
 gcode:
   RUN_SHELL_COMMAND CMD=Moonraker_Restore
+
+[gcode_macro RELOAD_CAMERA]
+gcode:
+  RUN_SHELL_COMMAND CMD=Reload_Camera
 
 
 [gcode_macro BED_LEVELING]

--- a/files/scripts/useful_macros.sh
+++ b/files/scripts/useful_macros.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+function reload_camera(){
+  echo -e "Info: Reload camera config..."
+  ACTION=reload /usr/bin/auto_uvc.sh
+  exit 0
+}
+
 function backup_klipper(){
   if [ -f /usr/data/printer_data/config/backup_config.tar.gz ]; then
     rm -f /usr/data/printer_data/config/backup_config.tar.gz
@@ -66,7 +72,9 @@ elif [ "$1" == "-backup_moonraker" ]; then
   backup_moonraker
 elif [ "$1" == "-restore_moonraker" ]; then
   restore_moonraker
+elif [ "$1" == "-reload_camera" ]; then
+  reload_camera
 else
-  echo -e "Invalid argument. Usage: $0 [-backup_klipper | -restore_klipper | -backup_moonraker | -restore_moonraker]"
+  echo -e "Invalid argument. Usage: $0 [-backup_klipper | -restore_klipper | -backup_moonraker | -restore_moonraker | -reload_camera]"
   exit 1
 fi

--- a/files/scripts/useful_macros.sh
+++ b/files/scripts/useful_macros.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-function reload_camera(){
-  echo -e "Info: Reload camera config..."
-  ACTION=reload /usr/bin/auto_uvc.sh
-  exit 0
-}
-
 function backup_klipper(){
   if [ -f /usr/data/printer_data/config/backup_config.tar.gz ]; then
     rm -f /usr/data/printer_data/config/backup_config.tar.gz
@@ -61,6 +55,12 @@ function restore_moonraker(){
   tar -xvf backup_database.tar.gz
   mv backup_database.tar.gz config/backup_database.tar.gz
   echo -e "Info: Moonraker database has been restored successfully!"
+  exit 0
+}
+
+function reload_camera(){
+  echo -e "Info: Reloading camera config..."
+  ACTION=reload /usr/bin/auto_uvc.sh
   exit 0
 }
 


### PR DESCRIPTION

![Screenshot 2024-04-25 101251](https://github.com/Guilouz/Creality-Helper-Script/assets/52493590/1c675edc-4311-4924-af67-2dd3978bd0d8)

I implemented a small camera reload feature that I thought can be useful to other too.

In order to restore a dead camera without a reboot, I found the feature, `ACTION=reload /usr/bin/auto_uvc.sh` in the creality startup scrips to reload the camera configs. I tested this is a shell and proceeded to add them to the `useful_macros.sh` and `useful-macros.cfg`.

I can now restore my camera feed without having to reboot and it only takes a few seconds to run.

it shows up in the klipper console like this:

```
09:44:29 
$ RELOAD_CAMERA
09:44:29 
// Running Command {Reload_Camera}...:
09:44:29 
// Info: Reload camera config...
09:44:29 
// stopped process in pidfile '/var/run/main-video-4.pid' (pid 1078)
09:44:29 
// stopped process in pidfile '/var/run/main-video-4_mjpg.pid' (pid 1085)
09:44:30 
// no process in pidfile '/var/run/main-video-5.pid' found; none killed
09:44:30 
// no process in pidfile '/var/run/main-video-5_mjpg.pid' found; none killed
09:44:30 
// Command {Reload_Camera} finished​
```
and I also checked the dmesg log:

```
[101764.491617] usb 1-1.1: USB disconnect, device number 21
[101764.497992] cdc_acm 1-1.1:1.0: acm_ctrl_irq - usb_submit_urb failed: -19
[101764.705719] usb 1-1.1: new full-speed USB device number 22 using dwc2
[101764.811251] usb 1-1.1: New USB device found, idVendor=1a86, idProduct=55d3
[101764.819751] usb 1-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=3
[101764.828253] usb 1-1.1: Product: USB Single Serial
[101764.835741] usb 1-1.1: SerialNumber: 5719024095
[101764.842581] cdc_acm 1-1.1:1.0: ttyACM0: USB ACM device
[102274.955490] usb 1-1.1: USB disconnect, device number 22
[102275.165014] usb 1-1.1: new full-speed USB device number 23 using dwc2
[102275.262618] usb 1-1.1: New USB device found, idVendor=1a86, idProduct=55d3
[102275.271342] usb 1-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=3
[102275.287284] usb 1-1.1: Product: USB Single Serial
[102275.292382] usb 1-1.1: SerialNumber: 5719024095
[102275.298970] cdc_acm 1-1.1:1.0: ttyACM0: USB ACM device
[102445.451809] usb 1-1.1: USB disconnect, device number 23
[102445.667399] usb 1-1.1: new full-speed USB device number 24 using dwc2
[102445.765267] usb 1-1.1: New USB device found, idVendor=1a86, idProduct=55d3
[102445.772541] usb 1-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=3
[102445.780509] usb 1-1.1: Product: USB Single Serial
[102445.785745] usb 1-1.1: SerialNumber: 5719024095
[102445.792134] cdc_acm 1-1.1:1.0: ttyACM0: USB ACM device
[103136.142131] usb 1-1.1: USB disconnect, device number 24
[103136.393259] usb 1-1.1: new full-speed USB device number 25 using dwc2
[103136.498874] usb 1-1.1: New USB device found, idVendor=1a86, idProduct=55d3
[103136.514112] usb 1-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=3
[103136.522223] usb 1-1.1: Product: USB Single Serial
[103136.527259] usb 1-1.1: SerialNumber: 5719024095
[103136.533821] cdc_acm 1-1.1:1.0: ttyACM0: USB ACM device
[103578.848395] IRQ Error, cpu: 0 Cause:0x08800000, Status:0x14001c00
[104054.411614] usb 1-1.1: USB disconnect, device number 25
[104054.618782] usb 1-1.1: new full-speed USB device number 26 using dwc2
[104054.712394] usb 1-1.1: New USB device found, idVendor=1a86, idProduct=55d3
[104054.720841] usb 1-1.1: New USB device strings: Mfr=0, Product=2, SerialNumber=3
[104054.728551] usb 1-1.1: Product: USB Single Serial
[104054.733778] usb 1-1.1: SerialNumber: 5719024095
[104054.744930] cdc_acm 1-1.1:1.0: ttyACM0: USB ACM device
[129645.557086] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[129645.606591] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[172858.782989] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[172858.807503] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[199029.798984] hrtimer: interrupt took 70499 ns
[202096.662303] IRQ Error, cpu: 1 Cause:0x08800000, Status:0x14001c00
[216071.943291] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[216072.076375] CFG80211-ERROR) wl_cfg80211_get_station : NOT assoc
[226764.813878] auto_uvc.sh (13583): drop_caches: 3
[226764.983940] RMEM: source not free, pid = 1078, name = cam_app, mem = 85765000, size = 921600
[226764.999842] RMEM: source not free, pid = 1078, name = cam_app, mem = 85846000, size = 462848
[226765.008813] helix-venc 13200000.helix: [3] encoder release
[226765.015110] helix-venc 13200000.helix: h264 stop streaming !
[226765.023220] RMEM: source not free, pid = 1078, name = cam_app, mem = 86587000, size = 921600
[226765.040679] RMEM: source not free, pid = 1078, name = cam_app, mem = 86668000, size = 462848
[226765.049971] helix-venc 13200000.helix: [2] encoder release
[226765.056022] helix-venc 13200000.helix: h264 stop streaming !
[226765.064240] helix-venc 13200000.helix: [1] encoder release
[226765.070186] helix-venc 13200000.helix: jpgd stop streaming !
[226765.079249] dwc2 13500000.otg_new: dwc2_hc_halt() Channel can't be halted
[226765.237643] uvcvideo: Failed to query (GET_LEN) UVC control 12 on unit 3: -32 (exp. 2).
[226765.871343] helix-venc 13200000.helix: V4L2_CID_JPEG_COMPRESSION_QUALITY = 1
[226765.878808] helix-venc 13200000.helix: Create instance [0]@8220a000 m2m_ctx=8dce7800
[226765.887260] helix-venc 13200000.helix: 13200000.helix vcodec [0]
[226765.894036] helix-venc 13200000.helix: jpgd start streaming
[226765.900180] helix-venc 13200000.helix: V4L2_CID_JPEG_COMPRESSION_QUALITY = 1
[226765.907996] helix-venc 13200000.helix: Create instance [1]@8220c000 m2m_ctx=8dce4000
[226765.916149] helix-venc 13200000.helix: 13200000.helix vcodec [1]
[226765.924544] rc_mode: vbr
[226765.927402] helix-venc 13200000.helix: h264 start streaming
[226765.933646] helix-venc 13200000.helix: V4L2_CID_JPEG_COMPRESSION_QUALITY = 1
[226765.941358] helix-venc 13200000.helix: Create instance [2]@8220e000 m2m_ctx=8dce1000
[226765.949481] helix-venc 13200000.helix: 13200000.helix vcodec [2]
[226765.957985] rc_mode: vbr
[226765.960843] helix-venc 13200000.helix: h264 start streaming

```