### PR TITLE
Main menu spelling fix

### DIFF
--- a/scripts/menu/main_menu.sh
+++ b/scripts/menu/main_menu.sh
@@ -62,7 +62,7 @@ function main_menu_ui() {
   main_menu_option '3' '[Customize]' 'Menu'
   main_menu_option '4' '[Backup & Restore]' 'Menu'
   main_menu_option '5' '[Tools]' 'Menu'
-  main_menu_option '6' '[Informations]' 'Menu'
+  main_menu_option '6' '[Information]' 'Menu'
   main_menu_option '7' '[System]' 'Menu'
   hr
   inner_line


### PR DESCRIPTION
Just a small spelling change. In French, "informations" is the correct plural form, but in English, "information" is used in the singular form without the "s".