### PR TITLE
Screws tilt adjust support for 3v3 KE

### DIFF
--- a/files/screws-tilt-adjust/screws-tilt-adjust-ke.cfg
+++ b/files/screws-tilt-adjust/screws-tilt-adjust-ke.cfg
@@ -1,0 +1,25 @@
+########################################
+# Screws Tilt Adjust for 3v3 KE
+########################################
+
+[screws_tilt_adjust]
+screw1: 27.5, -0.5
+screw1_name: front left screw
+screw2: 196.5, -0.5
+screw2_name: front right screw
+screw3: 196.5, 169.5
+screw3_name: rear right screw
+screw4: 27.5, 169.5
+screw4_name: rear left screw
+horizontal_move_z: 5
+speed: 150
+screw_thread: CCW-M4
+
+[gcode_macro SCREWS_CALIBRATION]
+description: Start Bed Screws Calibration
+gcode:
+  {% if printer.toolhead.homed_axes != "xyz" %}
+    G28
+  {% endif %}
+  SCREWS_TILT_CALCULATE
+  G0 X105 Y220 Z30

--- a/scripts/menu/KE/info_menu_KE.sh
+++ b/scripts/menu/KE/info_menu_KE.sh
@@ -47,6 +47,8 @@ function info_menu_ui_ke() {
   subtitle '•IMPROVEMENTS:'
   info_line "$(check_folder_ke "$IMP_SHAPERS_FOLDER")" 'Improved Shapers Calibrations'
   info_line "$(check_file_ke "$SAVE_ZOFFSET_FILE")" 'Save Z-Offset Macros'
+  info_line "$(check_file_ke "$SCREWS_ADJUST_FILE")" 'Screws Tilt Adjust Support'
+  info_line "$(check_file_ke "$M600_SUPPORT_FILE")" 'M600 Support'
   info_line "$(check_file_ke "$GIT_BACKUP_FILE")" 'Git Backup'
   hr
   subtitle '•CAMERA:'

--- a/scripts/menu/KE/install_menu_KE.sh
+++ b/scripts/menu/KE/install_menu_KE.sh
@@ -20,20 +20,21 @@ function install_menu_ui_ke() {
   menu_option ' 6' 'Install' 'Improved Shapers Calibrations'
   menu_option ' 7' 'Install' 'Save Z-Offset Macros'
   menu_option ' 8' 'Install' 'M600 Support'
-  menu_option ' 9' 'Install' 'Git Backup'
+  menu_option ' 9' 'Install' 'Screws Tilt Adjust Support'
+  menu_option '10' 'Install' 'Git Backup'
   hr
   subtitle '•CAMERA:'
-  menu_option '10' 'Install' 'Moonraker Timelapse'
-  menu_option '11' 'Install' 'Nebula Camera Settings Control'
-  menu_option '12' 'Install' 'USB Camera Support'
+  menu_option '11' 'Install' 'Moonraker Timelapse'
+  menu_option '12' 'Install' 'Nebula Camera Settings Control'
+  menu_option '13' 'Install' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '13' 'Install' 'OctoEverywhere'
-  menu_option '14' 'Install' 'Moonraker Obico'
-  menu_option '15' 'Install' 'GuppyFLO'
-  menu_option '16' 'Install' 'Mobileraker Companion'
-  menu_option '17' 'Install' 'OctoApp Companion'
-  menu_option '18' 'Install' 'SimplyPrint'
+  menu_option '14' 'Install' 'OctoEverywhere'
+  menu_option '15' 'Install' 'Moonraker Obico'
+  menu_option '16' 'Install' 'GuppyFLO'
+  menu_option '17' 'Install' 'Mobileraker Companion'
+  menu_option '18' 'Install' 'OctoApp Companion'
+  menu_option '19' 'Install' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -105,9 +106,15 @@ function install_menu_ke() {
         if [ -f "$M600_SUPPORT_FILE" ]; then
           error_msg "M600 Support is already installed!"
         else
-          run "install_m600_support" "install_menu_ui_k1"
+          run "install_m600_support" "install_menu_ui_ke"
         fi;;
       9)
+        if [ -f "$SCREWS_ADJUST_FILE" ]; then
+          error_msg "Screws Tilt Adjust Support is already installed!"
+        else
+          run "install_screws_tilt_adjust" "install_menu_ui_ke"
+        fi;;
+      10)
         if [ -f "$GIT_BACKUP_FILE" ]; then
           error_msg "Git Backup is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -117,7 +124,7 @@ function install_menu_ke() {
         else
           run "install_git_backup" "install_menu_ui_ke"
         fi;;
-      10)
+      11)
         if [ -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -125,7 +132,7 @@ function install_menu_ke() {
         else
           run "install_moonraker_timelapse" "install_menu_ui_ke"
         fi;;
-      11)
+      12)
         if [ -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Nebula Camera Settings Control is already installed!"
         elif ! v4l2-ctl --list-devices | grep -q 'CCX2F3298'; then
@@ -135,7 +142,7 @@ function install_menu_ke() {
         else
           run "install_camera_settings_control" "install_menu_ui_ke"
         fi;;
-      12)
+      13)
         if [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Camera USB Support is already installed!"
         elif v4l2-ctl --list-devices | grep -qE 'CREALITY|CCX2F3298'; then
@@ -145,7 +152,7 @@ function install_menu_ke() {
         else
           run "install_usb_camera" "install_menu_ui_ke"
         fi;;
-      13)
+      14)
         if [ -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -157,7 +164,7 @@ function install_menu_ke() {
         else
           run "install_octoeverywhere" "install_menu_ui_ke"
         fi;;
-      14)
+      15)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -167,13 +174,13 @@ function install_menu_ke() {
         else
           run "install_moonraker_obico" "install_menu_ui_ke"
         fi;;
-      15)
+      16)
         if [ ! -d "$MOONRAKER_FOLDER" ] && [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_guppyflo" "install_menu_ui_ke"
         fi;;
-      16)
+      17)
         if [ -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -185,7 +192,7 @@ function install_menu_ke() {
         else
           run "install_mobileraker_companion" "install_menu_ui_ke"
         fi;;
-      17)
+      18)
         if [ -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -197,7 +204,7 @@ function install_menu_ke() {
         else
           run "install_octoapp_companion" "install_menu_ui_ke"
         fi;;
-      18)
+      19)
         if grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then

--- a/scripts/menu/KE/remove_menu_KE.sh
+++ b/scripts/menu/KE/remove_menu_KE.sh
@@ -20,20 +20,21 @@ function remove_menu_ui_ke() {
   menu_option ' 6' 'Remove' 'Improved Shapers Calibrations'
   menu_option ' 7' 'Remove' 'Save Z-Offset Macros'
   menu_option ' 8' 'Remove' 'M600 Support'
-  menu_option ' 9' 'Remove' 'Git Backup'
+  menu_option ' 9' 'Remove' 'Screws Tilt Adjust Support'
+  menu_option '10' 'Remove' 'Git Backup'
   hr
   subtitle '•CAMERA:'
-  menu_option '10' 'Remove' 'Moonraker Timelapse'
-  menu_option '11' 'Install' 'Nebula Camera Settings Control'
-  menu_option '12' 'Remove' 'USB Camera Support'
+  menu_option '11' 'Remove' 'Moonraker Timelapse'
+  menu_option '12' 'Install' 'Nebula Camera Settings Control'
+  menu_option '13' 'Remove' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '13' 'Remove' 'OctoEverywhere'
-  menu_option '14' 'Remove' 'Moonraker Obico'
-  menu_option '15' 'Remove' 'GuppyFLO'
-  menu_option '16' 'Remove' 'Mobileraker Companion'
-  menu_option '17' 'Remove' 'OctoApp Companion'
-  menu_option '18' 'Remove' 'SimplyPrint'
+  menu_option '14' 'Remove' 'OctoEverywhere'
+  menu_option '15' 'Remove' 'Moonraker Obico'
+  menu_option '16' 'Remove' 'GuppyFLO'
+  menu_option '17' 'Remove' 'Mobileraker Companion'
+  menu_option '18' 'Remove' 'OctoApp Companion'
+  menu_option '19' 'Remove' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -126,60 +127,66 @@ function remove_menu_ke() {
           run "remove_m600_support" "remove_menu_ui_ke"
         fi;;
       9)
+        if [ ! -f "$SCREWS_ADJUST_FILE" ]; then
+          error_msg "Screws Tilt Adjust Support is not installed!"
+        else
+          run "remove_screws_tilt_adjust" "remove_menu_ui_ke"
+        fi;;
+      10)
         if [ ! -f "$GIT_BACKUP_FILE" ]; then
           error_msg "Git Backup is not installed!"
         else
           run "remove_git_backup" "remove_menu_ui_ke"
         fi;;
-      10)
+      11)
         if [ ! -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is not installed!"
         else
           run "remove_moonraker_timelapse" "remove_menu_ui_ke"
         fi;;
-      11)
+      12)
         if [ ! -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Nebula Camera Settings Control is not installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_ke"
         fi;;
-      12)
+      13)
         if [ ! -f "$USB_CAMERA_FILE" ]; then
           error_msg "USB Camera Support is not installed!"
         else
           run "remove_usb_camera" "remove_menu_ui_3v3"
         fi;;
-      13)
+      14)
         if [ ! -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is not installed!"
         else
           run "remove_octoeverywhere" "remove_menu_ui_ke"
         fi;;
-      14)
+      15)
         if [ ! -d "$MOONRAKER_OBICO_FOLDER" ]; then
           error_msg "Moonraker Obico is not installed!"
         else
           run "remove_moonraker_obico" "remove_menu_ui_ke"
         fi;;
-      15)
+      16)
         if [ ! -d "$GUPPYFLO_FOLDER" ]; then
           error_msg "GuppyFLO is not installed!"
         else
           run "remove_guppyflo" "remove_menu_ui_ke"
         fi;;
-      16)
+      17)
         if [ ! -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is not installed!"
         else
           run "remove_mobileraker_companion" "remove_menu_ui_ke"
         fi;;
-      17)
+      18)
         if [ ! -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is not installed!"
         else
           run "remove_octoapp_companion" "remove_menu_ui_ke"
         fi;;
-      18)
+      19)
         if ! grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is not installed!"
         else

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -115,6 +115,7 @@ function set_paths() {
   SCREWS_ADJUST_URL="${HS_FILES}/screws-tilt-adjust/screws_tilt_adjust.py"
   SCREWS_ADJUST_K1_URL="${HS_FILES}/screws-tilt-adjust/screws-tilt-adjust-k1.cfg"
   SCREWS_ADJUST_K1M_URL="${HS_FILES}/screws-tilt-adjust/screws-tilt-adjust-k1max.cfg"
+  SCREWS_ADJUST_KE_URL="${HS_FILES}/screws-tilt-adjust/screws-tilt-adjust-ke.cfg"
   
   # M600 Support #
   M600_SUPPORT_FILE="${HS_CONFIG_FOLDER}/M600-support.cfg"

--- a/scripts/screws_tilt_adjust.sh
+++ b/scripts/screws_tilt_adjust.sh
@@ -38,7 +38,7 @@ function install_screws_tilt_adjust(){
         echo
         local printer_choice
         while true; do
-          read -p " ${white}Do you want install it for ${yellow}K1${white} or ${yellow}K1 Max${white}? (${yellow}k1${white}/${yellow}k1max${white}): ${yellow}" printer_choice
+          read -p " ${white}Do you want to install it for ${yellow}K1${white}, ${yellow}K1 Max${white} or ${yellow}3v3 KE${white}? (${yellow}k1${white}/${yellow}k1max${white}/${yellow}ke${white}): ${yellow}" printer_choice
           case "${printer_choice}" in
             K1|k1)
               echo -e "${white}"
@@ -50,6 +50,11 @@ function install_screws_tilt_adjust(){
               echo -e "Info: Linking files..."
               ln -sf "$SCREWS_ADJUST_K1M_URL" "$HS_CONFIG_FOLDER"/screws-tilt-adjust.cfg
               break;;
+            KE|ke)
+              echo -e "${white}"
+              echo -e "Info: Linking files..."
+              ln -sf "$SCREWS_ADJUST_KE_URL" "$HS_CONFIG_FOLDER"/screws-tilt-adjust.cfg
+              break;;        
             *)
               error_msg "Please select a correct choice!";;
           esac


### PR DESCRIPTION
Added support for screws tilt adjust on 3v3 KE. Tested installation, removal, info menu, and of course results in action. Everything seems to be working fine, I ran auto bed leveling after getting all screw tilts to 00:00 and I think it's the lowest level variation I ever saw on my printer :)

I modified the gcode macro to park the extruder at some position at the end that is not obstructing any screws and allows for easy bed plate removal, because it's likely you'd have to run the adjustment lots of times and it's a pain to have to move it manually.