### PR TITLE
Use actual fanX_min instead of adding it to the fan speed

### DIFF
--- a/files/macros/fans-control.cfg
+++ b/files/macros/fans-control.cfg
@@ -98,41 +98,43 @@ gcode:
   {% if tmp > 0 %}
     {% if fan == 0 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
+      {% set f0min = printer["gcode_macro PRINTER_PARAM"].fan0_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan0_min + value}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={([f0min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
         {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
+          {% set value = ([f0min, value]|max) %}
         {% endif %}
       {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + value %}
       {% endif %}
     {% endif %}
     {% if fan == 1 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
+      {% set f1min = printer["gcode_macro PRINTER_PARAM"].fan1_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan1_min + value}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={([f1min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2 %}
         {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
+          {% set value = ([f1min,value]|max) %}
         {% endif %}
       {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + value %}
+        {% set value = ([f1min,value]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 2 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
+      {% set f2min = printer["gcode_macro PRINTER_PARAM"].fan2_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
-        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={printer["gcode_macro PRINTER_PARAM"].fan2_min + value}
+        SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={([f2min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2 %}
         {% else %}
-          {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
+          {% set value = ([f2min,value]|max) %}
         {% endif %}
       {% else %}
-        {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + value %}
+        {% set value = ([f2min,value]|max) %}
       {% endif %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
The current logic (from Creality) for M106 has values set in gcode_macro.cfg to specify minimum values for each fan. This makes sense to prevent the fan from failing to start or hovering at an ineffective speed. 

Unfortunately, the default logic simply adds the minimum value to the value set via M106. At higher fan values this is probably fine, but (for instance), setting fan0 to 25 (~10%), actually results in a fan speed of 50(~20%). This can cause issues with filaments that are sensitive to fan speed where a higher speed can cause warping.

This PR is to use the built-in jinja2 `|max` function to instead select the larger of either the minimum fan speed or the set value. This way we still keep the fan above the "minimum" value, but don't add any additional to values above that limit.