### PR TITLE
Fix soc fan getting stuck off.

### DIFF
--- a/files/macros/fans-control.cfg
+++ b/files/macros/fans-control.cfg
@@ -28,6 +28,7 @@ min_speed: 0.0
 [temperature_fan soc_fan]
 pin: PB2
 cycle_time: 0.0100
+kick_start_time: 0.5
 hardware_pwm: false
 max_power: 1
 shutdown_speed: 0


### PR DESCRIPTION
If SET_TEMPERATURE_FAN_TARGET is invoked on soc_fan while the cpu is saturated[1], fan can get stuck at 0 rpm. If the ambient temp is high enough, soc will overheat and crash.

You can also observe this by invoking SET_TEMPERATURE_FAN_TARGET while the cpu is idle. The fan rpms drop to 0 in mainsail before ramping up 1-2 seconds later.

Increasing kick_start_time[2] fixes this, by ensuring that the fan starts running (when applicable depending on temp target).

[1] e.g. INPUT_SHAPER_CALIBRATION or BELTS_SHAPER_CALIBRATION
[2] Default is 0.1 (sec).