### PR TITLE
Fix fan issue

### DIFF
--- a/files/macros/fans-control.cfg
+++ b/files/macros/fans-control.cfg
@@ -99,43 +99,47 @@ gcode:
   {% if tmp > 0 %}
     {% if fan == 0 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
+      {% set flatvalue = (255 * tmp %}
       {% set f0min = printer["gcode_macro PRINTER_PARAM"].fan0_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={([f0min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
         {% else %}
-          {% set value = ([f0min, value]|max) %}
+          {% set value = ([f0min, flatvalue]|max) %}
         {% endif %}
       {% else %}
+         {% set value = ([f0min, flatvalue]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 1 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
+      {% set flatvalue = (255 * tmp %}
       {% set f1min = printer["gcode_macro PRINTER_PARAM"].fan1_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={([f1min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2 %}
         {% else %}
-          {% set value = ([f1min,value]|max) %}
+          {% set value = ([f1min,flatvalue]|max) %}
         {% endif %}
       {% else %}
-        {% set value = ([f1min,value]|max) %}
+        {% set value = ([f1min,flatvalue]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 2 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
+      {% set flatvalue = (255 * tmp %}
       {% set f2min = printer["gcode_macro PRINTER_PARAM"].fan2_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={([f2min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2 %}
         {% else %}
-          {% set value = ([f2min,value]|max) %}
+          {% set value = ([f2min,flatvalue]|max) %}
         {% endif %}
       {% else %}
-        {% set value = ([f2min,value]|max) %}
+        {% set value = ([f2min,flatvalue]|max) %}
       {% endif %}
     {% endif %}
   {% endif %}

--- a/files/macros/fans-control.cfg
+++ b/files/macros/fans-control.cfg
@@ -105,10 +105,10 @@ gcode:
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
         {% else %}
-          {% set value = ([f0min, tmp]|max) %}
+          {% set value = ([f0min,tmp]|max) %}
         {% endif %}
       {% else %}
-         {% set value = ([f0min, tmp]|max) %}
+         {% set value = ([f0min,tmp]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 1 %}

--- a/files/macros/fans-control.cfg
+++ b/files/macros/fans-control.cfg
@@ -99,47 +99,44 @@ gcode:
   {% if tmp > 0 %}
     {% if fan == 0 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan0_min) / 255 * tmp %}
-      {% set flatvalue = (255 * tmp %}
       {% set f0min = printer["gcode_macro PRINTER_PARAM"].fan0_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan0_value VALUE={([f0min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan0_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan0_min) / 2 %}
         {% else %}
-          {% set value = ([f0min, flatvalue]|max) %}
+          {% set value = ([f0min, tmp]|max) %}
         {% endif %}
       {% else %}
-         {% set value = ([f0min, flatvalue]|max) %}
+         {% set value = ([f0min, tmp]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 1 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan1_min) / 255 * tmp %}
-      {% set flatvalue = (255 * tmp %}
       {% set f1min = printer["gcode_macro PRINTER_PARAM"].fan1_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan1_value VALUE={([f1min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan1_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan1_min) / 2 %}
         {% else %}
-          {% set value = ([f1min,flatvalue]|max) %}
+          {% set value = ([f1min,tmp]|max) %}
         {% endif %}
       {% else %}
-        {% set value = ([f1min,flatvalue]|max) %}
+        {% set value = ([f1min,tmp]|max) %}
       {% endif %}
     {% endif %}
     {% if fan == 2 %}
       {% set value = (255 - printer["gcode_macro PRINTER_PARAM"].fan2_min) / 255 * tmp %}
-      {% set flatvalue = (255 * tmp %}
       {% set f2min = printer["gcode_macro PRINTER_PARAM"].fan2_min %}
       {% if printer['gcode_macro Qmode'].flag | int == 1 %}
         SET_GCODE_VARIABLE MACRO=Qmode VARIABLE=fan2_value VALUE={([f2min,value]|max)}
         {% if value > (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2  %}
           {% set value = printer["gcode_macro PRINTER_PARAM"].fan2_min + (255 - printer['gcode_macro PRINTER_PARAM'].fan2_min) / 2 %}
         {% else %}
-          {% set value = ([f2min,flatvalue]|max) %}
+          {% set value = ([f2min,tmp]|max) %}
         {% endif %}
       {% else %}
-        {% set value = ([f2min,flatvalue]|max) %}
+        {% set value = ([f2min,tmp]|max) %}
       {% endif %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
A typo in the previous commit accidentally removed a line that sets the fan speed for non-qmode. This fix should restore that line and also address an issue where value could be off slightly near 100% fan speed.