### PR TITLE
Configure alternative git server for backups

### DIFF
--- a/files/git-backup/git-backup.sh
+++ b/files/git-backup/git-backup.sh
@@ -116,20 +116,20 @@ elif [ "$INSTALL" = 1 ]; then
         echo "${white}"
         echo "${darkred} ✗ Invalid Git URL!${white}"
         echo
-        read -p " Please enter your ${green}GitHub URL${white} and press Enter: ${yellow}" GIT_URL
+        read -p " Please enter your ${green}Git URL${white} and press Enter: ${yellow}" GIT_URL
     done
     echo "${white}"
-    read -p " Please enter your ${green}GitHub username${white} and press Enter: ${yellow}" USER_NAME
+    read -p " Please enter your ${green}Git username${white} and press Enter: ${yellow}" USER_NAME
     while [ -z "$USER_NAME" ]; do
         echo "${white}"
-        echo "${darkred} ✗ Invalid GitHub username!${white}"
+        echo "${darkred} ✗ Invalid Git username!${white}"
         echo
-        read -p " Please enter your ${green}GitHub username${white} and press Enter: ${yellow}" USER_NAME
+        read -p " Please enter your ${green}Git username${white} and press Enter: ${yellow}" USER_NAME
     done
     valid_email=false
     while [ "$valid_email" != true ]; do
         echo "${white}"
-        read -p " Please enter your ${green}GitHub email address${white} and press Enter: ${yellow}" USER_MAIL
+        read -p " Please enter your ${green}Git email address${white} and press Enter: ${yellow}" USER_MAIL
         echo "$USER_MAIL" | grep -E -q "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
         if [ $? -ne 0 ]; then
             echo "${white}"
@@ -139,40 +139,40 @@ elif [ "$INSTALL" = 1 ]; then
         fi
     done
     echo "${white}"
-    read -p " Please enter your ${green}GitHub repository name${white} and press Enter: ${yellow}" REPO_NAME
+    read -p " Please enter your ${green}Git repository name${white} and press Enter: ${yellow}" REPO_NAME
     while [ -z "$REPO_NAME" ]; do
         echo "${white}"
-        echo "${darkred} ✗ Invalid GitHub repository name!${white}"
+        echo "${darkred} ✗ Invalid Git repository name!${white}"
         echo
-        read -p " Please enter your ${green}GitHub repository name${white} and press Enter: ${yellow}" REPO_NAME
+        read -p " Please enter your ${green}Git repository name${white} and press Enter: ${yellow}" REPO_NAME
     done
     echo "${white}"
-    read -p " Please enter your ${green}GitHub branch name${white} and press Enter: ${yellow}" REPO_BRANCH
+    read -p " Please enter your ${green}Git branch name${white} and press Enter: ${yellow}" REPO_BRANCH
     while [ -z "$REPO_BRANCH" ]; do
         echo "${white}"
-        echo "${darkred} ✗ Invalid GitHub branch name!${white}"
+        echo "${darkred} ✗ Invalid Git branch name!${white}"
         echo
-        read -p " Please enter your ${green}GitHub branch name${white} and press Enter: ${yellow}" REPO_BRANCH
+        read -p " Please enter your ${green}Git branch name${white} and press Enter: ${yellow}" REPO_BRANCH
     done
     echo "${white}"
-    read -p " Please enter your ${green}GitHub personal access token${white} and press Enter: ${yellow}" GITHUB_TOKEN
-    while [ -z "$GITHUB_TOKEN" ]; do
+    read -p " Please enter your ${green}Git personal access token${white} and press Enter: ${yellow}" GIT_ACCESS_TOKEN
+    while [ -z "$GIT_ACCESS_TOKEN" ]; do
         echo "${white}"
-        echo "${darkred} ✗ Invalid GitHub personal access token!${white}"
+        echo "${darkred} ✗ Invalid Git personal access token!${white}"
         echo
-        read -p " Please enter your ${green}GitHub personal access token${white} and press Enter: ${yellow}" GITHUB_TOKEN
+        read -p " Please enter your ${green}Git personal access token${white} and press Enter: ${yellow}" GIT_ACCESS_TOKEN
     done
     echo "${white}"
     
     # Folder to be watched
     IFS=/usr/data/printer_data/config
     
-    # Connect config directory to github
+    # Connect config directory to git
     cd "$IFS" || exit
     git config --global user.name "$USER_NAME"
     git config --global user.email "$USER_MAIL"
     git init
-    git remote add origin "https://$USER_NAME:$GITHUB_TOKEN@$GIT_URL/$USER_NAME/$REPO_NAME.git"
+    git remote add origin "https://$USER_NAME:$GIT_ACCESS_TOKEN@$GIT_URL/$USER_NAME/$REPO_NAME.git"
     git checkout -b "$REPO_BRANCH"
     git add .
     git commit -m "Initial Backup"
@@ -233,7 +233,7 @@ elif [ "$INSTALL" = 1 ]; then
     fi
     ENV=/usr/data/helper-script-backup/git-backup/.env
     echo "IFS=$IFS" > "$ENV"
-    echo "GITHUB_TOKEN=$GITHUB_TOKEN" >> "$ENV"
+    echo "GIT_ACCESS_TOKEN=$GIT_ACCESS_TOKEN" >> "$ENV"
     echo "REMOTE=$REPO_NAME" >> "$ENV"
     echo "BRANCH=$REPO_BRANCH" >> "$ENV"
     echo "USER=$USER_NAME" >> "$ENV"

--- a/files/git-backup/git-backup.sh
+++ b/files/git-backup/git-backup.sh
@@ -111,6 +111,14 @@ elif [ "$INSTALL" = 1 ]; then
     
     # Prompt user for configuration
     echo "${white}"
+    read -p " Please enter your ${green}Git URL${white} and press Enter: ${yellow}" GIT_URL
+    while [ -z "$GIT_URL" ]; do
+        echo "${white}"
+        echo "${darkred} ✗ Invalid Git URL!${white}"
+        echo
+        read -p " Please enter your ${green}GitHub URL${white} and press Enter: ${yellow}" GIT_URL
+    done
+    echo "${white}"
     read -p " Please enter your ${green}GitHub username${white} and press Enter: ${yellow}" USER_NAME
     while [ -z "$USER_NAME" ]; do
         echo "${white}"
@@ -164,7 +172,7 @@ elif [ "$INSTALL" = 1 ]; then
     git config --global user.name "$USER_NAME"
     git config --global user.email "$USER_MAIL"
     git init
-    git remote add origin "https://$USER_NAME:$GITHUB_TOKEN@github.com/$USER_NAME/$REPO_NAME.git"
+    git remote add origin "https://$USER_NAME:$GITHUB_TOKEN@$GIT_URL/$USER_NAME/$REPO_NAME.git"
     git checkout -b "$REPO_BRANCH"
     git add .
     git commit -m "Initial Backup"
@@ -212,7 +220,7 @@ elif [ "$INSTALL" = 1 ]; then
         killall -q inotifywait >/dev/null 2>&1
         /opt/bin/opkg --autoremove remove inotifywait >/dev/null 2>&1
         echo "${white}${darkred} ✗ Authentication failed!"
-        echo "   Check your GitHub personal access token and restart Git Backup installation.${white}"
+        echo "   Check your Git server personal access token and restart Git Backup installation.${white}"
         echo
         exit 0
     else
@@ -229,6 +237,7 @@ elif [ "$INSTALL" = 1 ]; then
     echo "REMOTE=$REPO_NAME" >> "$ENV"
     echo "BRANCH=$REPO_BRANCH" >> "$ENV"
     echo "USER=$USER_NAME" >> "$ENV"
+    echo "GIT_URL=$GIT_URL" >> "$ENV"
     
     # Insert .env to init.d
     echo "Info: Copying file..."


### PR DESCRIPTION
## Improvement
The script asks for a custom URL for a git instance to use for backups.

A git instance could be any of selfhosted GitLab, Gitea, Forgejo or even other public services, such as Codeberg or gitlab.com.

## Notes
It work on my local Forgejo instance but I would like this to be tested by the community before merging. I'm not sure the current error handling is complete or sufficient for this enhancement.

Also, the docs will be updated once the PR gets approved but it will keep github.com as example instance. 