### PR TITLE
Better folder detection in helper.sh

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -3,7 +3,7 @@
 set -e
 clear
 
-HELPER_SCRIPT_FOLDER="$( cd "$( dirname "${0}" )" && pwd )"
+HELPER_SCRIPT_FOLDER="$(dirname "$(readlink -f "$0")")"
 for script in "${HELPER_SCRIPT_FOLDER}/scripts/"*.sh; do . "${script}"; done
 for script in "${HELPER_SCRIPT_FOLDER}/scripts/menu/"*.sh; do . "${script}"; done
 for script in "${HELPER_SCRIPT_FOLDER}/scripts/menu/K1/"*.sh; do . "${script}"; done


### PR DESCRIPTION
This way the user could symlink the helper.sh script to something like /usr/bin/ and have it in the path which allows to just call "helper.sh" everywhere in the shell.