### PR TITLE
Ender5 max support

### DIFF
--- a/files/buzzer-support/buzzer-support-e5m.cfg
+++ b/files/buzzer-support/buzzer-support-e5m.cfg
@@ -1,0 +1,9 @@
+[gcode_shell_command beep]
+command: beep
+timeout: 2
+verbose: False
+
+[gcode_macro BEEP] # звук бип. 
+description: Play a sound
+gcode:
+  RUN_SHELL_COMMAND CMD=beep 

--- a/files/macros/fans-control-e5m-definitions.cfg
+++ b/files/macros/fans-control-e5m-definitions.cfg
@@ -1,0 +1,28 @@
+[gcode_macro M106]
+description: Set Fan Speed. P0 for part
+gcode:
+  {% set fan_id = params.P|default(0)|int %}
+  {% if fan_id == 0 %}
+    {% set speed_param = params.S|default(255)|int %}
+    {% if speed_param > 0 %}
+      {% set speed = (speed_param|float / 255) %}
+    {% else %}
+      {% set speed = 0 %}
+    {% endif %}
+    SET_FAN_SPEED FAN=part SPEED={speed}
+  {% endif %}
+
+[gcode_macro M107]
+description: Set Fan Off. P0 for part
+gcode:
+  SET_FAN_SPEED FAN=part SPEED=0
+
+[gcode_macro TURN_OFF_FANS]
+description: Stop chamber, auxiliary and part fan
+gcode:
+    SET_FAN_SPEED FAN=part SPEED=0
+
+[gcode_macro TURN_ON_FANS]
+description: Turn on chamber, auxiliary and part fan
+gcode:
+    SET_FAN_SPEED FAN=part SPEED=1 

--- a/scripts/buzzer_support.sh
+++ b/scripts/buzzer_support.sh
@@ -27,7 +27,11 @@ function install_buzzer_support(){
           mkdir -p "$HS_CONFIG_FOLDER"
         fi
         echo -e "Info: Linking file..."
-        ln -sf "$BUZZER_URL" "$HS_CONFIG_FOLDER"/buzzer-support.cfg
+        if [ "$model" = "E5M" ]; then
+          ln -sf "$BUZZER_E5M_URL" "$HS_CONFIG_FOLDER"/buzzer-support.cfg
+        else
+          ln -sf "$BUZZER_URL" "$HS_CONFIG_FOLDER"/buzzer-support.cfg
+        fi
         if grep -q "include Helper-Script/buzzer-support" "$PRINTER_CFG" ; then
           echo -e "Info: Buzzer Support configurations are already enabled in printer.cfg file..."
         else

--- a/scripts/fans_control_macros.sh
+++ b/scripts/fans_control_macros.sh
@@ -21,43 +21,82 @@ function install_fans_control_macros(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
-        if [ -f "$HS_CONFIG_FOLDER"/fans-control.cfg ]; then
-          rm -f "$HS_CONFIG_FOLDER"/fans-control.cfg
-        fi
-        if [ ! -d "$HS_CONFIG_FOLDER" ]; then
-          mkdir -p "$HS_CONFIG_FOLDER"
-        fi
-        echo -e "Info: Linking file..."
-        ln -sf "$FAN_CONTROLS_URL" "$HS_CONFIG_FOLDER"/fans-control.cfg
-        if grep -q "include Helper-Script/fans-control" "$PRINTER_CFG" ; then
-          echo -e "Info: Fans Control Macros configurations are already enabled in printer.cfg file..."
+        if [ "$model" = "E5M" ]; then
+          # E5M Specific Logic
+          echo -e "Info: Applying E5M specific fan control macros..."
+          if [ ! -d "$HS_BACKUP_FOLDER" ]; then
+            mkdir -p "$HS_BACKUP_FOLDER"
+          fi
+          echo -e "Info: Backing up gcode_macro.cfg..."
+          cp "$MACROS_CFG" "$HS_BACKUP_FOLDER/gcode_macro.cfg.e5m_fans_backup_$(date +%Y%m%d%H%M%S)"
+
+          echo -e "Info: Removing existing M106 and M107 macros from gcode_macro.cfg..."
+          # Delete M106 section - from [gcode_macro M106] to the line before the next [ or end of file
+          sed -i.bak '/^\[gcode_macro M106\]/{:a;N;/\n\[/!s/\n.*//;Ta;P;D;}' "$MACROS_CFG"
+          # Delete M107 section - similarly
+          sed -i.bak '/^\[gcode_macro M107\]/{:a;N;/\n\[/!s/\n.*//;Ta;P;D;}' "$MACROS_CFG"
+          # A simpler approach if sections are known to be contiguous or last:
+          # sed -i '/^\[gcode_macro M106\]/,/^\[gcode_macro M107\]/{/^\[gcode_macro M107\]/!d;}' # if M107 is right after M106
+          # Or more generally, delete from start of section to next section or EOF:
+          sed -i -e '/^\[gcode_macro M106\]/{:loop1 N; /\n\[/!b loop1; /\n\[gcode_macro M106\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+          sed -i -e '/^\[gcode_macro M107\]/{:loop2 N; /\n\[/!b loop2; /\n\[gcode_macro M107\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+          # Fallback: Remove the lines if the previous sed commands were not fully effective or the sections are at the end.
+          sed -i '/^\[gcode_macro M106\]/,/^\s*$/d' "$MACROS_CFG" # Delete M106 block ending with empty line
+          sed -i '/^\[gcode_macro M107\]/,/^\s*$/d' "$MACROS_CFG" # Delete M107 block ending with empty line
+          # Clean up extra blank lines that might result from deletions
+          sed -i '/^$/N;/^\n$/D' "$MACROS_CFG"
+
+          echo -e "Info: Appending E5M fan definitions to gcode_macro.cfg..."
+          cat "$FAN_DEFINITIONS_E5M_URL" >> "$MACROS_CFG"
+
+          if [ ! -d "$HS_CONFIG_FOLDER" ]; then
+            mkdir -p "$HS_CONFIG_FOLDER"
+          fi
+          touch "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag"
         else
-          echo -e "Info: Adding Fans Control Macros configurations in printer.cfg file..."
-          sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/fans-control\.cfg\]' "$PRINTER_CFG"
-        fi
-        if grep -q "\[duplicate_pin_override\]" "$PRINTER_CFG" ; then
-          echo -e "Info: Disabling [duplicate_pin_override] configuration in printer.cfg file..."
-          sed -i '/^\[duplicate_pin_override\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$PRINTER_CFG"
-        else
-          echo -e "Info: [duplicate_pin_override] configuration is already disabled in printer.cfg file..."
-        fi
-        if grep -q "\[temperature_fan chamber_fan\]" "$PRINTER_CFG" ; then
-          echo -e "Info: Disabling [temperature_fan chamber_fan] configuration in printer.cfg file..."
-          sed -i '/^\[temperature_fan chamber_fan\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$PRINTER_CFG"
-        else
-          echo -e "Info: [temperature_fan chamber_fan] configuration is already disabled in printer.cfg file..."
-        fi
-        if grep -q "\[gcode_macro M106\]" "$MACROS_CFG" ; then
-          echo -e "Info: Disabling [gcode_macro M106] in gcode_macro.cfg file..."
-          sed -i '/^\[gcode_macro M106\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MACROS_CFG"
-        else
-          echo -e "Info: [gcode_macro M106] macro is already disabled in gcode_macro.cfg file..."
-        fi
-        if grep -q "\[gcode_macro M141\]" "$MACROS_CFG" ; then
-          echo -e "Info: Disabling [gcode_macro M141] in gcode_macro.cfg file..."
-          sed -i '/^\[gcode_macro M141\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MACROS_CFG"
-        else
-          echo -e "Info: [gcode_macro M141] macro is already disabled in gcode_macro.cfg file..."
+          # Original logic for other printers
+          if [ -f "$HS_CONFIG_FOLDER"/fans-control.cfg ]; then
+            rm -f "$HS_CONFIG_FOLDER"/fans-control.cfg
+          fi
+          if [ ! -d "$HS_CONFIG_FOLDER" ]; then
+            mkdir -p "$HS_CONFIG_FOLDER"
+          fi
+          echo -e "Info: Linking file..."
+          ln -sf "$FAN_CONTROLS_URL" "$HS_CONFIG_FOLDER"/fans-control.cfg
+          if grep -q "include Helper-Script/fans-control" "$PRINTER_CFG" ; then
+            echo -e "Info: Fans Control Macros configurations are already enabled in printer.cfg file..."
+          else
+            echo -e "Info: Adding Fans Control Macros configurations in printer.cfg file..."
+            sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/fans-control\.cfg\]' "$PRINTER_CFG"
+          fi
+          if grep -q "\[duplicate_pin_override\]" "$PRINTER_CFG" ; then
+            echo -e "Info: Disabling [duplicate_pin_override] configuration in printer.cfg file..."
+            sed -i '/^\[duplicate_pin_override\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$PRINTER_CFG"
+          else
+            echo -e "Info: [duplicate_pin_override] configuration is already disabled in printer.cfg file..."
+          fi
+          if grep -q "\[temperature_fan chamber_fan\]" "$PRINTER_CFG" ; then
+            echo -e "Info: Disabling [temperature_fan chamber_fan] configuration in printer.cfg file..."
+            sed -i '/^\[temperature_fan chamber_fan\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$PRINTER_CFG"
+          else
+            echo -e "Info: [temperature_fan chamber_fan] configuration is already disabled in printer.cfg file..."
+          fi
+          # For non-E5M, we still need to disable M106 if it exists, as fans-control.cfg provides its own.
+          # This part should ideally only affect non-E5M models after this modification.
+          if grep -q "^\[gcode_macro M106\]" "$MACROS_CFG" ; then
+            echo -e "Info: Disabling [gcode_macro M106] in gcode_macro.cfg file for non-E5M model (standard fans-control takes over)..."
+            sed -i '/^\[gcode_macro M106\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MACROS_CFG"
+          fi
+          if grep -q "^\[gcode_macro M107\]" "$MACROS_CFG" ; then # M107 is usually not in default gcode_macro.cfg but check anyway
+             echo -e "Info: Disabling [gcode_macro M107] in gcode_macro.cfg file for non-E5M model..."
+             sed -i '/^\[gcode_macro M107\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MACROS_CFG"
+          fi
+          if grep -q "\[gcode_macro M141\]" "$MACROS_CFG" ; then
+            echo -e "Info: Disabling [gcode_macro M141] in gcode_macro.cfg file..."
+            sed -i '/^\[gcode_macro M141\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MACROS_CFG"
+          else
+            echo -e "Info: [gcode_macro M141] macro is already disabled in gcode_macro.cfg file..."
+          fi
         fi
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
@@ -80,40 +119,73 @@ function remove_fans_control_macros(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
-        echo -e "Info: Removing file..."
-        rm -f "$HS_CONFIG_FOLDER"/fans-control.cfg
-        if grep -q "include Helper-Script/fans-control" "$PRINTER_CFG" ; then
-          echo -e "Info: Removing Fans Control Macros configurations in printer.cfg file..."
-          sed -i '/include Helper-Script\/fans-control\.cfg/d' "$PRINTER_CFG"
+        if [ "$model" = "E5M" ]; then
+          # E5M Specific Removal Logic
+          echo -e "Info: Removing E5M specific fan control macros..."
+          latest_backup=$(ls -t "$HS_BACKUP_FOLDER"/gcode_macro.cfg.e5m_fans_backup_* 2>/dev/null | head -n 1)
+          if [ -f "$latest_backup" ]; then
+            echo -e "Info: Restoring gcode_macro.cfg from $latest_backup..."
+            cp "$latest_backup" "$MACROS_CFG"
+            rm "$latest_backup"
+          else
+            echo -e "Warning: No backup found for gcode_macro.cfg. Attempting to remove E5M fan macros directly."
+            # Fallback: Remove the E5M macros by their definition headers
+            sed -i -e '/^\[gcode_macro M106\]/{:loop1 N; /\n\[/!b loop1; /\n\[gcode_macro M106\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+            sed -i -e '/^\[gcode_macro M107\]/{:loop2 N; /\n\[/!b loop2; /\n\[gcode_macro M107\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+            sed -i -e '/^\[gcode_macro TURN_OFF_FANS\]/{:loop3 N; /\n\[/!b loop3; /\n\[gcode_macro TURN_OFF_FANS\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+            sed -i -e '/^\[gcode_macro TURN_ON_FANS\]/{:loop4 N; /\n\[/!b loop4; /\n\[gcode_macro TURN_ON_FANS\]/P; D}' -e 's/\n$//' "$MACROS_CFG"
+            sed -i '/^$/N;/^\n$/D' "$MACROS_CFG"
+          fi
+          rm -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag"
         else
-          echo -e "Info: Fans Control Macros configurations are already removed in printer.cfg file..."
+          # Original logic for other printers
+          echo -e "Info: Removing file..."
+          rm -f "$HS_CONFIG_FOLDER"/fans-control.cfg
+          if grep -q "include Helper-Script/fans-control" "$PRINTER_CFG" ; then
+            echo -e "Info: Removing Fans Control Macros configurations in printer.cfg file..."
+            sed -i '/include Helper-Script\/fans-control\.cfg/d' "$PRINTER_CFG"
+          else
+            echo -e "Info: Fans Control Macros configurations are already removed in printer.cfg file..."
+          fi
+          if grep -q "#\[duplicate_pin_override\]" "$PRINTER_CFG" ; then
+            echo -e "Info: Enabling [duplicate_pin_override] in printer.cfg file..."
+            sed -i -e 's/^\s*#[[:space:]]*\[duplicate_pin_override\]/[duplicate_pin_override]/' -e '/^\[duplicate_pin_override\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$PRINTER_CFG"
+          else
+            echo -e "Info: [duplicate_pin_override] is already enabled in printer.cfg file..."
+          fi
+          if grep -q "#\[temperature_fan chamber_fan\]" "$PRINTER_CFG" ; then
+            echo -e "Info: Enabling [temperature_fan chamber_fan] in printer.cfg file..."
+            sed -i -e 's/^\s*#[[:space:]]*\[temperature_fan chamber_fan\]/[temperature_fan chamber_fan]/' -e '/^\[temperature_fan chamber_fan\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$PRINTER_CFG"
+          else
+            echo -e "Info: [temperature_fan chamber_fan] is already enabled in printer.cfg file..."
+          fi
+          # For non-E5M, re-enable M106 and M107 if they were commented out.
+          # This assumes they were originally present and commented by this script.
+          if grep -q "#\[gcode_macro M106\]" "$MACROS_CFG" ; then
+            echo -e "Info: Enabling [gcode_macro M106] in gcode_macro.cfg file for non-E5M model..."
+            sed -i -e 's/^\s*#[[:space:]]*\[gcode_macro M106\]/[gcode_macro M106]/' -e '/^\[gcode_macro M106\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MACROS_CFG"
+          fi
+          if grep -q "#\[gcode_macro M107\]" "$MACROS_CFG" ; then
+             echo -e "Info: Enabling [gcode_macro M107] in gcode_macro.cfg file for non-E5M model..."
+             sed -i -e 's/^\s*#[[:space:]]*\[gcode_macro M107\]/[gcode_macro M107]/' -e '/^\[gcode_macro M107\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MACROS_CFG"
+          fi
+          if grep -q "#\[gcode_macro M141\]" "$MACROS_CFG" ; then
+            echo -e "Info: Enabling [gcode_macro M141] in gcode_macro.cfg file..."
+            sed -i -e 's/^\s*#[[:space:]]*\[gcode_macro M141\]/[gcode_macro M141]/' -e '/^\[gcode_macro M141\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MACROS_CFG"
+          else
+            echo -e "Info: [gcode_macro M141] is already enabled in gcode_macro.cfg file..."
+          fi
         fi
-        if grep -q "#\[duplicate_pin_override\]" "$PRINTER_CFG" ; then
-          echo -e "Info: Enabling [duplicate_pin_override] in printer.cfg file..."
-          sed -i -e 's/^\s*#[[:space:]]*\[duplicate_pin_override\]/[duplicate_pin_override]/' -e '/^\[duplicate_pin_override\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$PRINTER_CFG"
-        else
-          echo -e "Info: [duplicate_pin_override] is already enabled in printer.cfg file..."
-        fi
-        if grep -q "#\[temperature_fan chamber_fan\]" "$PRINTER_CFG" ; then
-          echo -e "Info: Enabling [temperature_fan chamber_fan] in printer.cfg file..."
-          sed -i -e 's/^\s*#[[:space:]]*\[temperature_fan chamber_fan\]/[temperature_fan chamber_fan]/' -e '/^\[temperature_fan chamber_fan\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$PRINTER_CFG"
-        else
-          echo -e "Info: [temperature_fan chamber_fan] is already enabled in printer.cfg file..."
-        fi
-        if grep -q "#\[gcode_macro M106\]" "$MACROS_CFG" ; then
-          echo -e "Info: Enabling [gcode_macro M106] in gcode_macro.cfg file..."
-          sed -i -e 's/^\s*#[[:space:]]*\[gcode_macro M106\]/[gcode_macro M106]/' -e '/^\[gcode_macro M106\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MACROS_CFG"
-        else
-          echo -e "Info: [gcode_macro M106] is already enabled in gcode_macro.cfg file..."
-        fi
-        if grep -q "#\[gcode_macro M141\]" "$MACROS_CFG" ; then
-          echo -e "Info: Enabling [gcode_macro M141] in gcode_macro.cfg file..."
-          sed -i -e 's/^\s*#[[:space:]]*\[gcode_macro M141\]/[gcode_macro M141]/' -e '/^\[gcode_macro M141\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MACROS_CFG"
-        else
-          echo -e "Info: [gcode_macro M141] is already enabled in gcode_macro.cfg file..."
-        fi
-        if [ ! -n "$(ls -A "$HS_CONFIG_FOLDER")" ]; then
+        # Check if HS_CONFIG_FOLDER is empty only if not E5M or if flag is also gone for E5M
+        if [ "$model" != "E5M" ] && [ ! -n "$(ls -A "$HS_CONFIG_FOLDER" 2>/dev/null)" ]; then
           rm -rf "$HS_CONFIG_FOLDER"
+        elif [ "$model" = "E5M" ] && [ ! -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag" ] && [ ! -n "$(ls -A "$HS_CONFIG_FOLDER" 2>/dev/null | grep -v 'e5m_custom_fan_definitions_applied.flag')" ]; then
+           # If E5M, and flag is gone, and dir is empty OR only contains other E5M flags for other features, then consider removing.
+           # This logic might need to be more robust if other E5M flags exist.
+           # Simplified: if flag is gone and dir is otherwise empty, rm it.
+           if [ ! "$(ls -A "$HS_CONFIG_FOLDER" 2>/dev/null | grep -v '^e5m_custom_fan_definitions_applied.flag$' | tr -d '\n')" ]; then
+             rm -rf "$HS_CONFIG_FOLDER"
+           fi 
         fi
         echo -e "Info: Restarting Klipper service..."
         restart_klipper

--- a/scripts/menu/E5M/install_menu_E5M.sh
+++ b/scripts/menu/E5M/install_menu_E5M.sh
@@ -27,15 +27,16 @@ function install_menu_ui_e5m() {
   subtitle '•CAMERA:'
   menu_option '12' 'Install' 'Moonraker Timelapse'
   menu_option '13' 'Install' 'Camera Settings Control'
-  menu_option '14' 'Install' 'USB Camera Support'
+  menu_option '14' 'Install' 'Nebula Camera Support'
+  menu_option '15' 'Install' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '15' 'Install' 'OctoEverywhere'
-  menu_option '16' 'Install' 'Moonraker Obico'
-  menu_option '17' 'Install' 'GuppyFLO'
-  menu_option '18' 'Install' 'Mobileraker Companion'
-  menu_option '19' 'Install' 'OctoApp Companion'
-  menu_option '20' 'Install' 'SimplyPrint'
+  menu_option '16' 'Install' 'OctoEverywhere'
+  menu_option '17' 'Install' 'Moonraker Obico'
+  menu_option '18' 'Install' 'GuppyFLO'
+  menu_option '19' 'Install' 'Mobileraker Companion'
+  menu_option '20' 'Install' 'OctoApp Companion'
+  menu_option '21' 'Install' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -150,22 +151,20 @@ function install_menu_e5m() {
           run "install_camera_settings_control" "install_menu_ui_e5m"
         fi;;
       14)
+        if [ -f "$CAMERA_SETTINGS_FILE" ] || [ -f "$NEBULA_CAMERA_FILE" ]; then
+          error_msg "Nebula Camera Support (or generic Camera Settings) might already be installed!"
+        elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
+          error_msg "Klipper Gcode Shell Command is needed, please install it first!"
+        else
+          run "install_camera_settings_control" "install_menu_ui_e5m"
+        fi;;
+      15)
         if [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Camera USB Support is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
           error_msg "Entware is needed, please install it first!"
         else
           run "install_usb_camera" "install_menu_ui_e5m"
-        fi;;
-      15)
-        if [ ! -d "$MOONRAKER_FOLDER" ]; then
-          error_msg "Moonraker and Nginx are needed, please install them first!"
-        elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
-          error_msg "Fluidd or Mainsail is needed, please install one of them first!"
-        elif [ ! -f "$ENTWARE_FILE" ]; then
-          error_msg "Entware is needed, please install it first!"
-        else
-          run "install_octoeverywhere" "install_menu_ui_e5m"
         fi;;
       16)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -175,15 +174,25 @@ function install_menu_e5m() {
         elif [ ! -f "$ENTWARE_FILE" ]; then
           error_msg "Entware is needed, please install it first!"
         else
-          run "install_moonraker_obico" "install_menu_ui_e5m"
+          run "install_octoeverywhere" "install_menu_ui_e5m"
         fi;;
       17)
+        if [ ! -d "$MOONRAKER_FOLDER" ]; then
+          error_msg "Moonraker and Nginx are needed, please install them first!"
+        elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
+          error_msg "Fluidd or Mainsail is needed, please install one of them first!"
+        elif [ ! -f "$ENTWARE_FILE" ]; then
+          error_msg "Entware is needed, please install it first!"
+        else
+          run "install_moonraker_obico" "install_menu_ui_e5m"
+        fi;;
+      18)
         if [ ! -d "$MOONRAKER_FOLDER" ] && [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_guppyflo" "install_menu_ui_e5m"
         fi;;
-      18)
+      19)
         if [ -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -195,7 +204,7 @@ function install_menu_e5m() {
         else
           run "install_mobileraker_companion" "install_menu_ui_e5m"
         fi;;
-      19)
+      20)
         if [ -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -207,7 +216,7 @@ function install_menu_e5m() {
         else
           run "install_octoapp_companion" "install_menu_ui_e5m"
         fi;;
-      20)
+      21)
         if grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then

--- a/scripts/menu/E5M/install_menu_E5M.sh
+++ b/scripts/menu/E5M/install_menu_E5M.sh
@@ -26,17 +26,16 @@ function install_menu_ui_e5m() {
   hr
   subtitle '•CAMERA:'
   menu_option '12' 'Install' 'Moonraker Timelapse'
-  menu_option '13' 'Install' 'Camera Settings Control'
-  menu_option '14' 'Install' 'Nebula Camera Support'
-  menu_option '15' 'Install' 'USB Camera Support'
+  menu_option '13' 'Install' 'Nebula Camera Support'
+  menu_option '14' 'Install' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '16' 'Install' 'OctoEverywhere'
-  menu_option '17' 'Install' 'Moonraker Obico'
-  menu_option '18' 'Install' 'GuppyFLO'
-  menu_option '19' 'Install' 'Mobileraker Companion'
-  menu_option '20' 'Install' 'OctoApp Companion'
-  menu_option '21' 'Install' 'SimplyPrint'
+  menu_option '15' 'Install' 'OctoEverywhere'
+  menu_option '16' 'Install' 'Moonraker Obico'
+  menu_option '17' 'Install' 'GuppyFLO'
+  menu_option '18' 'Install' 'Mobileraker Companion'
+  menu_option '19' 'Install' 'OctoApp Companion'
+  menu_option '20' 'Install' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -141,16 +140,6 @@ function install_menu_e5m() {
           run "install_moonraker_timelapse" "install_menu_ui_e5m"
         fi;;
       13)
-        if [ -f "$CAMERA_SETTINGS_FILE" ]; then
-          error_msg "Camera Settings Control is already installed!"
-        elif v4l2-ctl --list-devices | grep -q 'CCX2F3299' && [ ! -f "$INITD_FOLDER"/S50usb_camera ]; then
-          error_msg "This is not compatible with the new hardware version of the camera!"
-        elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
-          error_msg "Klipper Gcode Shell Command is needed, please install it first!"
-        else
-          run "install_camera_settings_control" "install_menu_ui_e5m"
-        fi;;
-      14)
         if [ -f "$CAMERA_SETTINGS_FILE" ] || [ -f "$NEBULA_CAMERA_FILE" ]; then
           error_msg "Nebula Camera Support (or generic Camera Settings) might already be installed!"
         elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
@@ -158,7 +147,7 @@ function install_menu_e5m() {
         else
           run "install_camera_settings_control" "install_menu_ui_e5m"
         fi;;
-      15)
+      14)
         if [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Camera USB Support is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -166,7 +155,7 @@ function install_menu_e5m() {
         else
           run "install_usb_camera" "install_menu_ui_e5m"
         fi;;
-      16)
+      15)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -176,7 +165,7 @@ function install_menu_e5m() {
         else
           run "install_octoeverywhere" "install_menu_ui_e5m"
         fi;;
-      17)
+      16)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -186,13 +175,13 @@ function install_menu_e5m() {
         else
           run "install_moonraker_obico" "install_menu_ui_e5m"
         fi;;
-      18)
+      17)
         if [ ! -d "$MOONRAKER_FOLDER" ] && [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_guppyflo" "install_menu_ui_e5m"
         fi;;
-      19)
+      18)
         if [ -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -204,7 +193,7 @@ function install_menu_e5m() {
         else
           run "install_mobileraker_companion" "install_menu_ui_e5m"
         fi;;
-      20)
+      19)
         if [ -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -216,8 +205,8 @@ function install_menu_e5m() {
         else
           run "install_octoapp_companion" "install_menu_ui_e5m"
         fi;;
-      21)
-        if grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
+      20)
+        if grep -q "\\\\[simplyprint\\\\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"

--- a/scripts/menu/E5M/install_menu_E5M.sh
+++ b/scripts/menu/E5M/install_menu_E5M.sh
@@ -17,29 +17,25 @@ function install_menu_ui_e5m() {
   menu_option ' 5' 'Install' 'Klipper Gcode Shell Command'
   hr
   subtitle '•IMPROVEMENTS:'
-  menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
-  menu_option ' 7' 'Install' 'Buzzer Support'
-  menu_option ' 8' 'Install' 'Nozzle Cleaning Fan Control'
-  menu_option ' 9' 'Install' 'Fans Control Macros'
-  menu_option '10' 'Install' 'Improved Shapers Calibrations'
-  menu_option '11' 'Install' 'Useful Macros'
-  menu_option '12' 'Install' 'Save Z-Offset Macros'
-  menu_option '13' 'Install' 'Screws Tilt Adjust Support'
-  menu_option '14' 'Install' 'M600 Support'
-  menu_option '15' 'Install' 'Git Backup'
+  menu_option ' 6' 'Install' 'Buzzer Support'
+  menu_option ' 7' 'Install' 'Fans Control Macros'
+  menu_option ' 8' 'Install' 'Improved Shapers Calibrations'
+  menu_option ' 9' 'Install' 'Useful Macros'
+  menu_option '10' 'Install' 'Save Z-Offset Macros'
+  menu_option '11' 'Install' 'Screws Tilt Adjust Support'
   hr
   subtitle '•CAMERA:'
-  menu_option '16' 'Install' 'Moonraker Timelapse'
-  menu_option '17' 'Install' 'Camera Settings Control'
-  menu_option '18' 'Install' 'USB Camera Support'
+  menu_option '12' 'Install' 'Moonraker Timelapse'
+  menu_option '13' 'Install' 'Camera Settings Control'
+  menu_option '14' 'Install' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '19' 'Install' 'OctoEverywhere'
-  menu_option '20' 'Install' 'Moonraker Obico'
-  menu_option '21' 'Install' 'GuppyFLO'
-  menu_option '22' 'Install' 'Mobileraker Companion'
-  menu_option '23' 'Install' 'OctoApp Companion'
-  menu_option '24' 'Install' 'SimplyPrint'
+  menu_option '15' 'Install' 'OctoEverywhere'
+  menu_option '16' 'Install' 'Moonraker Obico'
+  menu_option '17' 'Install' 'GuppyFLO'
+  menu_option '18' 'Install' 'Mobileraker Companion'
+  menu_option '19' 'Install' 'OctoApp Companion'
+  menu_option '20' 'Install' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -92,12 +88,6 @@ function install_menu_e5m() {
           run "install_gcode_shell_command" "install_menu_ui_e5m"
         fi;;
       6)
-        if [ -d "$KAMP_FOLDER" ]; then
-          error_msg "Klipper Adaptive Meshing & Purging is already installed!"
-        else
-          run "install_kamp" "install_menu_ui_e5m"
-        fi;;
-      7)
         if [ -f "$BUZZER_FILE" ]; then
           error_msg "Buzzer Support is already installed!"
         elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
@@ -105,19 +95,13 @@ function install_menu_e5m() {
         else
           run "install_buzzer_support" "install_menu_ui_e5m"
         fi;;
-      8)
-        if [ -d "$NOZZLE_CLEANING_FOLDER" ]; then
-          error_msg "Nozzle Cleaning Fan Control is already installed!"
-        else
-          run "install_nozzle_cleaning_fan_control" "install_menu_ui_e5m"
-        fi;;
-      9)
+      7)
         if [ -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag" ]; then
           error_msg "E5M Custom Fan Macros are already applied!"
         else
           run "install_fans_control_macros" "install_menu_ui_e5m"
         fi;;
-      10)
+      8)
         if [ -d "$IMP_SHAPERS_FOLDER" ]; then
           error_msg "Improved Shapers Calibrations are already installed!"
         elif [ -d "$GUPPY_SCREEN_FOLDER" ]; then
@@ -127,7 +111,7 @@ function install_menu_e5m() {
         else
           run "install_improved_shapers" "install_menu_ui_e5m"
         fi;;
-      11)
+      9)
         if [ -f "$USEFUL_MACROS_FILE" ]; then
           error_msg "Useful Macros are already installed!"
         elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
@@ -135,35 +119,19 @@ function install_menu_e5m() {
         else
           run "install_useful_macros" "install_menu_ui_e5m"
         fi;;
-      12)
+      10)
         if [ -f "$SAVE_ZOFFSET_FILE" ]; then
           error_msg "Save Z-Offset Macros are already installed!"
         else
           run "install_save_zoffset_macros" "install_menu_ui_e5m"
         fi;;
-      13)
+      11)
         if [ -f "$SCREWS_ADJUST_FILE" ]; then
           error_msg "Screws Tilt Adjust Support is already installed!"
         else
           run "install_screws_tilt_adjust" "install_menu_ui_e5m"
         fi;;
-      14)
-        if [ -f "$M600_SUPPORT_FILE" ]; then
-          error_msg "M600 Support is already installed!"
-        else
-          run "install_m600_support" "install_menu_ui_e5m"
-        fi;;
-      15)
-        if [ -f "$GIT_BACKUP_FILE" ]; then
-          error_msg "Git Backup is already installed!"
-        elif [ ! -f "$ENTWARE_FILE" ]; then
-          error_msg "Entware is needed, please install it first!"
-        elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
-          error_msg "Klipper Gcode Shell Command is needed, please install it first!"
-        else
-          run "install_git_backup" "install_menu_ui_e5m"
-        fi;;
-      16)
+      12)
         if [ -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -171,7 +139,7 @@ function install_menu_e5m() {
         else
           run "install_moonraker_timelapse" "install_menu_ui_e5m"
         fi;;
-      17)
+      13)
         if [ -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Camera Settings Control is already installed!"
         elif v4l2-ctl --list-devices | grep -q 'CCX2F3299' && [ ! -f "$INITD_FOLDER"/S50usb_camera ]; then
@@ -181,7 +149,7 @@ function install_menu_e5m() {
         else
           run "install_camera_settings_control" "install_menu_ui_e5m"
         fi;;
-      18)
+      14)
         if [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Camera USB Support is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -189,7 +157,7 @@ function install_menu_e5m() {
         else
           run "install_usb_camera" "install_menu_ui_e5m"
         fi;;
-      19)
+      15)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -199,7 +167,7 @@ function install_menu_e5m() {
         else
           run "install_octoeverywhere" "install_menu_ui_e5m"
         fi;;
-      20)
+      16)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -209,13 +177,13 @@ function install_menu_e5m() {
         else
           run "install_moonraker_obico" "install_menu_ui_e5m"
         fi;;
-      21)
+      17)
         if [ ! -d "$MOONRAKER_FOLDER" ] && [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_guppyflo" "install_menu_ui_e5m"
         fi;;
-      22)
+      18)
         if [ -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -227,7 +195,7 @@ function install_menu_e5m() {
         else
           run "install_mobileraker_companion" "install_menu_ui_e5m"
         fi;;
-      23)
+      19)
         if [ -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -239,7 +207,7 @@ function install_menu_e5m() {
         else
           run "install_octoapp_companion" "install_menu_ui_e5m"
         fi;;
-      24)
+      20)
         if grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then

--- a/scripts/menu/E5M/install_menu_E5M.sh
+++ b/scripts/menu/E5M/install_menu_E5M.sh
@@ -112,8 +112,8 @@ function install_menu_e5m() {
           run "install_nozzle_cleaning_fan_control" "install_menu_ui_e5m"
         fi;;
       9)
-        if [ -f "$FAN_CONTROLS_FILE" ]; then
-          error_msg "Fans Control Macros are already installed!"
+        if [ -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag" ]; then
+          error_msg "E5M Custom Fan Macros are already applied!"
         else
           run "install_fans_control_macros" "install_menu_ui_e5m"
         fi;;

--- a/scripts/menu/E5M/remove_menu_E5M.sh
+++ b/scripts/menu/E5M/remove_menu_E5M.sh
@@ -26,17 +26,16 @@ function remove_menu_ui_e5m() {
   hr
   subtitle '•CAMERA:'
   menu_option '12' 'Remove' 'Moonraker Timelapse'
-  menu_option '13' 'Remove' 'Camera Settings Control'
-  menu_option '14' 'Remove' 'Nebula Camera Support'
-  menu_option '15' 'Remove' 'USB Camera Support'
+  menu_option '13' 'Remove' 'Nebula Camera Support'
+  menu_option '14' 'Remove' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '16' 'Remove' 'OctoEverywhere'
-  menu_option '17' 'Remove' 'Moonraker Obico'
-  menu_option '18' 'Remove' 'GuppyFLO'
-  menu_option '19' 'Remove' 'Mobileraker Companion'
-  menu_option '20' 'Remove' 'OctoApp Companion'
-  menu_option '21' 'Remove' 'SimplyPrint'
+  menu_option '15' 'Remove' 'OctoEverywhere'
+  menu_option '16' 'Remove' 'Moonraker Obico'
+  menu_option '17' 'Remove' 'GuppyFLO'
+  menu_option '18' 'Remove' 'Mobileraker Companion'
+  menu_option '19' 'Remove' 'OctoApp Companion'
+  menu_option '20' 'Remove' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -155,55 +154,49 @@ function remove_menu_e5m() {
           run "remove_moonraker_timelapse" "remove_menu_ui_e5m"
         fi;;
       13)
-        if [ ! -f "$CAMERA_SETTINGS_FILE" ]; then
-          error_msg "Camera Settings Control is not installed!"
-        else
-          run "remove_camera_settings_control" "remove_menu_ui_e5m"
-        fi;;
-      14)
         if [ ! -f "$CAMERA_SETTINGS_FILE" ] && [ ! -f "$NEBULA_CAMERA_FILE" ]; then
           error_msg "Nebula Camera Support (or generic Camera Settings) does not appear to be installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_e5m"
         fi;;
-      15)
+      14)
         if [ ! -f "$USB_CAMERA_FILE" ]; then
           error_msg "USB Camera Support is not installed!"
         else
           run "remove_usb_camera" "remove_menu_ui_e5m"
         fi;;
-      16)
+      15)
         if [ ! -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is not installed!"
         else
           run "remove_octoeverywhere" "remove_menu_ui_e5m"
         fi;;
-      17)
+      16)
         if [ ! -d "$MOONRAKER_OBICO_FOLDER" ]; then
           error_msg "Moonraker Obico is not installed!"
         else
           run "remove_moonraker_obico" "remove_menu_ui_e5m"
         fi;;
-      18)
+      17)
         if [ ! -d "$GUPPYFLO_FOLDER" ]; then
           error_msg "GuppyFLO is not installed!"
         else
           run "remove_guppyflo" "remove_menu_ui_e5m"
         fi;;
-      19)
+      18)
         if [ ! -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is not installed!"
         else
           run "remove_mobileraker_companion" "remove_menu_ui_e5m"
         fi;;
-      20)
+      19)
         if [ ! -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is not installed!"
         else
           run "remove_octoapp_companion" "remove_menu_ui_e5m"
         fi;;
-      21)
-        if ! grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
+      20)
+        if ! grep -q "\\\\[simplyprint\\\\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is not installed!"
         else
           run "remove_simplyprint" "remove_menu_ui_e5m"

--- a/scripts/menu/E5M/remove_menu_E5M.sh
+++ b/scripts/menu/E5M/remove_menu_E5M.sh
@@ -17,29 +17,25 @@ function remove_menu_ui_e5m() {
   menu_option ' 5' 'Remove' 'Klipper Gcode Shell Command'
   hr
   subtitle '•IMPROVEMENTS:'
-  menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
-  menu_option ' 7' 'Remove' 'Buzzer Support'
-  menu_option ' 8' 'Remove' 'Nozzle Cleaning Fan Control'
-  menu_option ' 9' 'Remove' 'Fans Control Macros'
-  menu_option '10' 'Remove' 'Improved Shapers Calibrations'
-  menu_option '11' 'Remove' 'Useful Macros'
-  menu_option '12' 'Remove' 'Save Z-Offset Macros'
-  menu_option '13' 'Remove' 'Screws Tilt Adjust Support'
-  menu_option '14' 'Remove' 'M600 Support'
-  menu_option '15' 'Remove' 'Git Backup'
+  menu_option ' 6' 'Remove' 'Buzzer Support'
+  menu_option ' 7' 'Remove' 'Fans Control Macros'
+  menu_option ' 8' 'Remove' 'Improved Shapers Calibrations'
+  menu_option ' 9' 'Remove' 'Useful Macros'
+  menu_option '10' 'Remove' 'Save Z-Offset Macros'
+  menu_option '11' 'Remove' 'Screws Tilt Adjust Support'
   hr
   subtitle '•CAMERA:'
-  menu_option '16' 'Remove' 'Moonraker Timelapse'
-  menu_option '17' 'Remove' 'Camera Settings Control'
-  menu_option '18' 'Remove' 'USB Camera Support'
+  menu_option '12' 'Remove' 'Moonraker Timelapse'
+  menu_option '13' 'Remove' 'Camera Settings Control'
+  menu_option '14' 'Remove' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '19' 'Remove' 'OctoEverywhere'
-  menu_option '20' 'Remove' 'Moonraker Obico'
-  menu_option '21' 'Remove' 'GuppyFLO'
-  menu_option '22' 'Remove' 'Mobileraker Companion'
-  menu_option '23' 'Remove' 'OctoApp Companion'
-  menu_option '24' 'Remove' 'SimplyPrint'
+  menu_option '15' 'Remove' 'OctoEverywhere'
+  menu_option '16' 'Remove' 'Moonraker Obico'
+  menu_option '17' 'Remove' 'GuppyFLO'
+  menu_option '18' 'Remove' 'Mobileraker Companion'
+  menu_option '19' 'Remove' 'OctoApp Companion'
+  menu_option '20' 'Remove' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -90,8 +86,6 @@ function remove_menu_e5m() {
           error_msg "Entware is not installed!"
         elif [ -f "$TIMELAPSE_FILE" ]; then
           error_msg "Entware is needed to use Moonraker Timelapse, please uninstall it first!"
-        elif [ -f "$GIT_BACKUP_FILE" ]; then
-          error_msg "Entware is needed to use Git Backup, please uninstall it first!"
         elif [ -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "Entware is needed to use OctoEverywhere, please uninstall it first!"
         elif [ -d "$MOONRAKER_OBICO_FOLDER" ]; then
@@ -112,122 +106,96 @@ function remove_menu_e5m() {
           error_msg "Klipper Gcode Shell Command is needed to use Guppy Screen, please uninstall it first!"
         elif [ -d "$IMP_SHAPERS_FOLDER" ]; then
           error_msg "Klipper Gcode Shell Command is needed to use Improved Shapers Calibrations, please uninstall it first!"
-        elif [ -f "$GIT_BACKUP_FILE" ]; then
-          error_msg "Klipper Gcode Shell Command is needed to use Git Backup, please uninstall it first!"
         elif [ -f "$USEFUL_MACROS_FILE" ]; then
           error_msg "Klipper Gcode Shell Command is needed to use Useful Macros, please uninstall it first!"
         else
           run "remove_gcode_shell_command" "remove_menu_ui_e5m"
         fi;;
       6)
-        if [ ! -d "$KAMP_FOLDER" ]; then
-          error_msg "Klipper Adaptive Meshing & Purging is not installed!"
-        else
-          run "remove_kamp" "remove_menu_ui_e5m"
-        fi;;
-      7)
         if [ ! -f "$BUZZER_FILE" ]; then
           error_msg "Buzzer Support is not installed!"
         else
           run "remove_buzzer_support" "remove_menu_ui_e5m"
         fi;;
-      8)
-        if [ ! -d "$NOZZLE_CLEANING_FOLDER" ]; then
-          error_msg "Nozzle Cleaning Fan Control is not installed!"
-        else
-          run "remove_nozzle_cleaning_fan_control" "remove_menu_ui_e5m"
-        fi;;
-      9)
+      7)
         if [ ! -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag" ]; then
           error_msg "E5M Custom Fan Macros are not applied!"
         else
           run "remove_fans_control_macros" "remove_menu_ui_e5m"
         fi;;
-      10)
+      8)
         if [ ! -d "$IMP_SHAPERS_FOLDER" ]; then
           error_msg "Improved Shapers Calibrations are not installed!"
         else
           run "remove_improved_shapers" "remove_menu_ui_e5m"
         fi;;
-      11)
+      9)
         if [ ! -f "$USEFUL_MACROS_FILE" ]; then
           error_msg "Useful Macros are not installed!"
         else
           run "remove_useful_macros" "remove_menu_ui_e5m"
         fi;;
-      12)
+      10)
         if [ ! -f "$SAVE_ZOFFSET_FILE" ]; then
           error_msg "Save Z-Offset Macros are not installed!"
         else
           run "remove_save_zoffset_macros" "remove_menu_ui_e5m"
         fi;;
-      13)
+      11)
         if [ ! -f "$SCREWS_ADJUST_FILE" ]; then
           error_msg "Screws Tilt Adjust Support is not installed!"
         else
           run "remove_screws_tilt_adjust" "remove_menu_ui_e5m"
         fi;;
-      14)
-        if [ ! -f "$M600_SUPPORT_FILE" ]; then
-          error_msg "M600 Support is not installed!"
-        else
-          run "remove_m600_support" "remove_menu_ui_e5m"
-        fi;;
-      15)
-        if [ ! -f "$GIT_BACKUP_FILE" ]; then
-          error_msg "Git Backup is not installed!"
-        else
-          run "remove_git_backup" "remove_menu_ui_e5m"
-        fi;;
-      16)
+      12)
         if [ ! -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is not installed!"
         else
           run "remove_moonraker_timelapse" "remove_menu_ui_e5m"
         fi;;
-      17)
+      13)
         if [ ! -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Camera Settings Control is not installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_e5m"
         fi;;
-      18)
+      14)
         if [ ! -f "$USB_CAMERA_FILE" ]; then
           error_msg "USB Camera Support is not installed!"
         else
           run "remove_usb_camera" "remove_menu_ui_e5m"
         fi;;
-      19)
+      15)
         if [ ! -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is not installed!"
         else
           run "remove_octoeverywhere" "remove_menu_ui_e5m"
         fi;;
-      20)
+      16)
         if [ ! -d "$MOONRAKER_OBICO_FOLDER" ]; then
           error_msg "Moonraker Obico is not installed!"
         else
           run "remove_moonraker_obico" "remove_menu_ui_e5m"
         fi;;
-      21)
+      17)
         if [ ! -d "$GUPPYFLO_FOLDER" ]; then
           error_msg "GuppyFLO is not installed!"
         else
           run "remove_guppyflo" "remove_menu_ui_e5m"
         fi;;
-      22)
+      18)
         if [ ! -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is not installed!"
         else
           run "remove_mobileraker_companion" "remove_menu_ui_e5m"
         fi;;
-      23)
+      19)
         if [ ! -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is not installed!"
         else
           run "remove_octoapp_companion" "remove_menu_ui_e5m"
         fi;;
-      24)
+      20)
         if ! grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is not installed!"
         else

--- a/scripts/menu/E5M/remove_menu_E5M.sh
+++ b/scripts/menu/E5M/remove_menu_E5M.sh
@@ -27,15 +27,16 @@ function remove_menu_ui_e5m() {
   subtitle '•CAMERA:'
   menu_option '12' 'Remove' 'Moonraker Timelapse'
   menu_option '13' 'Remove' 'Camera Settings Control'
-  menu_option '14' 'Remove' 'USB Camera Support'
+  menu_option '14' 'Remove' 'Nebula Camera Support'
+  menu_option '15' 'Remove' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '15' 'Remove' 'OctoEverywhere'
-  menu_option '16' 'Remove' 'Moonraker Obico'
-  menu_option '17' 'Remove' 'GuppyFLO'
-  menu_option '18' 'Remove' 'Mobileraker Companion'
-  menu_option '19' 'Remove' 'OctoApp Companion'
-  menu_option '20' 'Remove' 'SimplyPrint'
+  menu_option '16' 'Remove' 'OctoEverywhere'
+  menu_option '17' 'Remove' 'Moonraker Obico'
+  menu_option '18' 'Remove' 'GuppyFLO'
+  menu_option '19' 'Remove' 'Mobileraker Companion'
+  menu_option '20' 'Remove' 'OctoApp Companion'
+  menu_option '21' 'Remove' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -160,42 +161,48 @@ function remove_menu_e5m() {
           run "remove_camera_settings_control" "remove_menu_ui_e5m"
         fi;;
       14)
+        if [ ! -f "$CAMERA_SETTINGS_FILE" ] && [ ! -f "$NEBULA_CAMERA_FILE" ]; then
+          error_msg "Nebula Camera Support (or generic Camera Settings) does not appear to be installed!"
+        else
+          run "remove_camera_settings_control" "remove_menu_ui_e5m"
+        fi;;
+      15)
         if [ ! -f "$USB_CAMERA_FILE" ]; then
           error_msg "USB Camera Support is not installed!"
         else
           run "remove_usb_camera" "remove_menu_ui_e5m"
         fi;;
-      15)
+      16)
         if [ ! -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is not installed!"
         else
           run "remove_octoeverywhere" "remove_menu_ui_e5m"
         fi;;
-      16)
+      17)
         if [ ! -d "$MOONRAKER_OBICO_FOLDER" ]; then
           error_msg "Moonraker Obico is not installed!"
         else
           run "remove_moonraker_obico" "remove_menu_ui_e5m"
         fi;;
-      17)
+      18)
         if [ ! -d "$GUPPYFLO_FOLDER" ]; then
           error_msg "GuppyFLO is not installed!"
         else
           run "remove_guppyflo" "remove_menu_ui_e5m"
         fi;;
-      18)
+      19)
         if [ ! -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is not installed!"
         else
           run "remove_mobileraker_companion" "remove_menu_ui_e5m"
         fi;;
-      19)
+      20)
         if [ ! -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is not installed!"
         else
           run "remove_octoapp_companion" "remove_menu_ui_e5m"
         fi;;
-      20)
+      21)
         if ! grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is not installed!"
         else

--- a/scripts/menu/E5M/remove_menu_E5M.sh
+++ b/scripts/menu/E5M/remove_menu_E5M.sh
@@ -138,8 +138,8 @@ function remove_menu_e5m() {
           run "remove_nozzle_cleaning_fan_control" "remove_menu_ui_e5m"
         fi;;
       9)
-        if [ ! -f "$FAN_CONTROLS_FILE" ]; then
-          error_msg "Fans Control Macros are not installed!"
+        if [ ! -f "$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag" ]; then
+          error_msg "E5M Custom Fan Macros are not applied!"
         else
           run "remove_fans_control_macros" "remove_menu_ui_e5m"
         fi;;

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -97,6 +97,7 @@ function set_paths() {
   # Fans Control Macros #
   FAN_CONTROLS_FILE="${HS_CONFIG_FOLDER}/fans-control.cfg"
   FAN_CONTROLS_URL="${HS_FILES}/macros/fans-control.cfg"
+  FAN_DEFINITIONS_E5M_URL="${HS_FILES}/macros/fans-control-e5m-definitions.cfg"
   
   # Improved Shapers Calibrations #
   IMP_SHAPERS_FOLDER="${HS_CONFIG_FOLDER}/improved-shapers"

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -86,6 +86,7 @@ function set_paths() {
   # Buzzer Support #
   BUZZER_FILE="${HS_CONFIG_FOLDER}/buzzer-support.cfg"
   BUZZER_URL="${HS_FILES}/buzzer-support/buzzer-support.cfg"
+  BUZZER_E5M_URL="${HS_FILES}/buzzer-support/buzzer-support-e5m.cfg"
   
   # Nozzle Cleaning Fan Control #
   NOZZLE_CLEANING_FOLDER="${KLIPPER_EXTRAS_FOLDER}/prtouch_v2_fan"


### PR DESCRIPTION
Current state - ready


`git clone --branch ender5_max_support  --single-branch https://github.com/supfeer/Creality-Helper-Script.git /usr/data/helper-script-e5m`

`sh /usr/data/helper-script-e5m/helper.sh`



## Общие инструкции:
Убедитесь, что ваш принтер определяется как "E5M" (модель "F004") для всех тестов.

## 1. Тестирование специфичных функций E5M (основано на коммите `d908a16`):

### Поддержка Зуммера (Buzzer Support)
*   **Расположение в меню E5M:** Опция 6 (Install/Remove Menu).
*   **Установка:**
    *   Проверьте, что `$HS_CONFIG_FOLDER/buzzer-support.cfg` создан как символическая ссылка на `files/buzzer-support/buzzer-support-e5m.cfg`.
    *   Проверьте, что `printer.cfg` содержит `[include Helper-Script/buzzer-support.cfg]`.
    *   Протестируйте G-code команду `BEEP`.
*   **Удаление:**
    *   Проверьте, что символическая ссылка и включение в `printer.cfg` удалены.

### Макросы Управления Вентиляторами (Fans Control Macros)
*   **Расположение в меню E5M:** Опция 7 (Install/Remove Menu).
*   **Перед установкой:** Убедитесь, что `gcode_macro.cfg` либо не содержит секций `[gcode_macro M106]` / `[gcode_macro M107]`, либо содержит стандартные.
*   **Установка (E5M):**
    *   Проверьте создание резервной копии `gcode_macro.cfg` в `$HS_BACKUP_FOLDER` (например, `gcode_macro.cfg.e5m_fans_backup_YYYYMMDDHHMMSS`).
    *   Проверьте, что стандартные секции `[gcode_macro M106]` и `[gcode_macro M107]` удалены из основного `gcode_macro.cfg`.
    *   Проверьте, что содержимое `files/macros/fans-control-e5m-definitions.cfg` добавлено в `gcode_macro.cfg`.
    *   Проверьте наличие файла-флага `$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag`.
    *   Убедитесь, что `printer.cfg` *не* включает `Helper-Script/fans-control.cfg`.
    *   Протестируйте G-code команды `M106` и `M107`.
*   **Удаление (E5M):**
    *   Проверьте восстановление `gcode_macro.cfg` из резервной копии (если существует).
    *   Проверьте удаление файла резервной копии.
    *   Проверьте удаление файла-флага.
    *   (Опционально) Если бэкап отсутствовал, проверьте удаление макросов `sed`-командами.
*   **Установка/Удаление (модель не E5M, например, K1):**
    *   Переключитесь на контекст другой модели.
    *   Установите и затем удалите "Fans Control Macros", проверяя стандартную логику (линковка `fans-control.cfg`, включение в `printer.cfg`, комментирование/раскомментирование конфликтующих секций).

### Регулировка Наклона Стола Винтами (Screws Tilt Adjust)
*   **Расположение в меню E5M:** Опция 11 (Install/Remove Menu).
*   **Установка:**
    *   Проверьте, что `$HS_CONFIG_FOLDER/screws-tilt-adjust.cfg` является символической ссылкой на `files/screws-tilt-adjust/screws-tilt-adjust-e5m.cfg`.
    *   Проверьте содержимое связанного файла `screws-tilt-adjust-e5m.cfg` на корректный порядок винтов: задний правый, задний левый, передний левый, передний правый.

## 2. Тестирование структуры меню E5M (после коммитов `0d1a0dd` и `6d872bb`, а также удалений пунктов меню):

### Меню Установки E5M (`scripts/menu/E5M/install_menu_E5M.sh`):
*   Перейдите в "Install Menu" для E5M.
*   **Убедитесь, что следующие пункты ОТСУТСТВУЮТ:**
    *   `Klipper Adaptive Meshing & Purging`
    *   `Nozzle Cleaning Fan Control`
    *   `M600 Support`
    *   `Git Backup`
    *   `Camera Settings Control`
*   **Проверьте нумерацию и наличие следующих пунктов (общее количество 20):**
    *   **ESSENTIALS:** (1-3)
        *   1: Moonraker and Nginx
        *   2: Fluidd
        *   3: Mainsail
    *   **UTILITIES:** (4-5)
        *   4: Entware
        *   5: Klipper Gcode Shell Command
    *   **IMPROVEMENTS:** (6-11)
        *   6: Buzzer Support
        *   7: Fans Control Macros
        *   8: Improved Shapers Calibrations
        *   9: Useful Macros
        *   10: Save Z-Offset Macros
        *   11: Screws Tilt Adjust Support
    *   **CAMERA:** (12-14)
        *   12: Moonraker Timelapse
        *   13: Nebula Camera Support (проверьте, что вызывает `install_camera_settings_control` или выдает ошибку при отсутствии зависимостей/наличии файла)
        *   14: USB Camera Support
    *   **REMOTE ACCESS:** (15-20)
        *   15: OctoEverywhere
        *   16: Moonraker Obico
        *   17: GuppyFLO
        *   18: Mobileraker Companion
        *   19: OctoApp Companion
        *   20: SimplyPrint

### Меню Удаления E5M (`scripts/menu/E5M/remove_menu_E5M.sh`):
*   Перейдите в "Remove Menu" для E5M.
*   **Убедитесь, что ОТСУТСТВУЮТ те же пункты, что и в меню установки.**
*   **Проверьте нумерацию и наличие пунктов аналогично меню установки (общее количество 20).**
*   Опция 13 "Nebula Camera Support" должна вызывать `remove_camera_settings_control` или выдавать ошибку, если не установлена.
*   **Проверьте зависимости при удалении:**
    *   При попытке удаления "Entware" (опция 4), убедитесь, что скрипт *не* проверяет наличие "Git Backup" как зависимость.
    *   При попытке удаления "Klipper Gcode Shell Command" (опция 5), убедитесь, что скрипт *не* проверяет наличие "Git Backup" как зависимость, но *проверяет* зависимости от других установленных функций, которые его требуют (Buzzer, Nebula/Camera Settings, Improved Shapers, Useful Macros).

## 3. Тестирование функциональности "Save Z-Offset Macros" (запрос был, изменений в коде не было):
*   **Расположение в меню E5M:** Опция 10 (Install/Remove Menu).
*   **Установка:** Установите "Save Z-Offset Macros".
*   **Действие:** Сохраните Z-смещение через стандартные команды Klipper.
*   **Проверка:** Перезагрузите Klipper (или принтер). Убедитесь, что после перезагрузки сохраненное Z-смещение было автоматически применено. 

---

# Testing Instructions for E5M

## General Instructions:
Ensure your printer is identified as "E5M" (model "F004") for all tests.

## 1. Testing E5M Specific Functions (based on commit `d908a16`):

### Buzzer Support
*   **Location in E5M Menu:** Option 6 (Install/Remove Menu).
*   **Installation:**
    *   Verify that `$HS_CONFIG_FOLDER/buzzer-support.cfg` is created as a symbolic link to `files/buzzer-support/buzzer-support-e5m.cfg`.
    *   Verify that `printer.cfg` includes `[include Helper-Script/buzzer-support.cfg]`.
    *   Test the `BEEP` G-code command.
*   **Removal:**
    *   Verify that the symbolic link and the include in `printer.cfg` are removed.

### Fans Control Macros
*   **Location in E5M Menu:** Option 7 (Install/Remove Menu).
*   **Before Installation:** Ensure `gcode_macro.cfg` either has no `[gcode_macro M106]` / `[gcode_macro M107]` sections or has standard ones.
*   **Installation (E5M):**
    *   Verify that a backup of `gcode_macro.cfg` is created in `$HS_BACKUP_FOLDER` (e.g., `gcode_macro.cfg.e5m_fans_backup_YYYYMMDDHHMMSS`).
    *   Verify that standard `[gcode_macro M106]` and `[gcode_macro M107]` sections are removed from the main `gcode_macro.cfg`.
    *   Verify that the contents of `files/macros/fans-control-e5m-definitions.cfg` are appended to `gcode_macro.cfg`.
    *   Verify the flag file `$HS_CONFIG_FOLDER/e5m_custom_fan_definitions_applied.flag` is created.
    *   Ensure that `printer.cfg` does *not* include `Helper-Script/fans-control.cfg`.
    *   Test `M106` and `M107` G-code commands.
*   **Removal (E5M):**
    *   Verify restoration of `gcode_macro.cfg` from backup (if one exists).
    *   Verify deletion of the backup file.
    *   Verify deletion of the flag file.
    *   (Optional) If no backup existed, verify macro removal by `sed` commands.
*   **Installation/Removal (Non-E5M model, e.g., K1):**
    *   Switch to a different model context.
    *   Install and then remove "Fans Control Macros," verifying standard logic (linking `fans-control.cfg`, inclusion in `printer.cfg`, commenting/uncommenting conflicting sections).

### Screws Tilt Adjust
*   **Location in E5M Menu:** Option 11 (Install/Remove Menu).
*   **Installation:**
    *   Verify that `$HS_CONFIG_FOLDER/screws-tilt-adjust.cfg` is a symbolic link to `files/screws-tilt-adjust/screws-tilt-adjust-e5m.cfg`.
    *   Check the contents of the linked `screws-tilt-adjust-e5m.cfg` for the correct screw order: rear right, rear left, front left, front right.

## 2. Testing E5M Menu Structure (after commits `0d1a0dd` and `6d872bb`, and menu item removals):

### E5M Install Menu (`scripts/menu/E5M/install_menu_E5M.sh`):
*   Navigate to the "Install Menu" for E5M.
*   **Ensure the following items are ABSENT:**
    *   `Klipper Adaptive Meshing & Purging`
    *   `Nozzle Cleaning Fan Control`
    *   `M600 Support`
    *   `Git Backup`
    *   `Camera Settings Control`
*   **Verify numbering and presence of the following items (total 20):**
    *   **ESSENTIALS:** (1-3)
        *   1: Moonraker and Nginx
        *   2: Fluidd
        *   3: Mainsail
    *   **UTILITIES:** (4-5)
        *   4: Entware
        *   5: Klipper Gcode Shell Command
    *   **IMPROVEMENTS:** (6-11)
        *   6: Buzzer Support
        *   7: Fans Control Macros
        *   8: Improved Shapers Calibrations
        *   9: Useful Macros
        *   10: Save Z-Offset Macros
        *   11: Screws Tilt Adjust Support
    *   **CAMERA:** (12-14)
        *   12: Moonraker Timelapse
        *   13: Nebula Camera Support (verify it calls `install_camera_settings_control` or errors if dependencies are missing/file exists)
        *   14: USB Camera Support
    *   **REMOTE ACCESS:** (15-20)
        *   15: OctoEverywhere
        *   16: Moonraker Obico
        *   17: GuppyFLO
        *   18: Mobileraker Companion
        *   19: OctoApp Companion
        *   20: SimplyPrint

### E5M Remove Menu (`scripts/menu/E5M/remove_menu_E5M.sh`):
*   Navigate to the "Remove Menu" for E5M.
*   **Ensure the SAME items listed for the install menu are ABSENT.**
*   **Verify numbering and presence of items similar to the install menu (total 20).**
*   Option 13 "Nebula Camera Support" should call `remove_camera_settings_control` or error if not installed.
*   **Verify dependencies on removal:**
    *   When attempting to remove "Entware" (option 4), ensure the script does *not* check for "Git Backup" as a dependency.
    *   When attempting to remove "Klipper Gcode Shell Command" (option 5), ensure the script does *not* check for "Git Backup" but *does* check for dependencies on other installed features that require it (Buzzer, Nebula/Camera Settings, Improved Shapers, Useful Macros).

## 3. Testing "Save Z-Offset Macros" Functionality (request existed, no code changes):
*   **Location in E5M Menu:** Option 10 (Install/Remove Menu).
*   **Installation:** Install "Save Z-Offset Macros".
*   **Action:** Save Z-offset using standard Klipper commands.
*   **Verification:** Restart Klipper (or the printer). Ensure that the saved Z-offset has been automatically applied after the restart.


