### PR TITLE
Don't set executable bit on guppy_screen.sh

### DIFF
--- a/scripts/guppy_screen.sh
+++ b/scripts/guppy_screen.sh
@@ -141,7 +141,6 @@ function install_guppy_screen(){
           fi
           cp "$GUPPY_SCREEN_CONFIG_3V3_URL" "$GUPPY_SCREEN_FOLDER"/guppyconfig.json
         fi
-        chmod 775 "$GUPPY_SCREEN_URL2"
         if grep -q "include GuppyScreen" "$PRINTER_CFG" ; then
           echo -e "Info: Guppy Screen configurations are already enabled in printer.cfg file."
         else


### PR DESCRIPTION
Setting this bit is not necessary as guppy_update.cfg invokes the script with the `sh` interpreter, and setting it needlessly dirties the helper script repo as seen in the update manager UI.

See https://github.com/Guilouz/Creality-Helper-Script-Wiki/discussions/821.