### PR TITLE
Add KAMP for 3KE

### DIFF
--- a/files/kamp/KAMP_Settings.cfg
+++ b/files/kamp/KAMP_Settings.cfg
@@ -28,7 +28,7 @@ variable_fuzz_amount: 0                     # Slightly randomizes mesh points to
 variable_purge_height: 0.8                  # Z position of nozzle during purge. Default is 0.8.
 variable_tip_distance: 0                    # Distance between tip of filament and nozzle before purge. Default is 0.
 variable_purge_margin: 10                   # Distance the purge will be in front of the print area. Default is 10.
-variable_purge_amount: 50                   # Amount of filament to be purged prior to printing. Default is 50.
+variable_purge_amount: 30                   # Amount of filament [length in mm] to be purged prior to printing. Default is 30.
 variable_flow_rate: 12                      # Flow rate of purge in mm3/s. Default is 12.
 
 # The following variables are for adjusting Smart Park feature, which will park the printhead near the print area at a specified height:

--- a/files/kamp/Start_Print-3ke.cfg
+++ b/files/kamp/Start_Print-3ke.cfg
@@ -1,0 +1,163 @@
+##############################################
+# Additional Macros for Creality Ender-3 V3 KE
+##############################################
+
+[respond]
+
+[virtual_pins]
+
+[output_pin ADAPTIVE_BED_MESH]
+pin: virtual_pin:ADAPTIVE_BED_MESH_pin
+value: 1
+
+[output_pin FULL_BED_MESH]
+pin: virtual_pin:FULL_BED_MESH_pin
+value: 0
+
+[output_pin ADAPTIVE_PURGE_LINE]
+pin: virtual_pin:ADAPTIVE_PURGE_LINE_pin
+value: 1
+
+
+[gcode_macro _ADAPTIVE_BED_MESH_ON]
+description: Enable Adaptive Bed Mesh and Disable Full Bed Mesh
+gcode:
+  SET_PIN PIN=ADAPTIVE_BED_MESH VALUE=1
+  SET_PIN PIN=FULL_BED_MESH VALUE=0
+  RESPOND TYPE=command MSG="action:prompt_end"
+
+
+[gcode_macro _FULL_BED_MESH_ON]
+description: Disable Adaptive Bed Mesh and Enable Full Bed Mesh
+gcode:
+  SET_PIN PIN=ADAPTIVE_BED_MESH VALUE=0
+  SET_PIN PIN=FULL_BED_MESH VALUE=1
+  RESPOND TYPE=command MSG="action:prompt_end"
+
+
+[gcode_macro _BED_MESH_OFF]
+description: Disable Adaptive Bed Mesh and Enable Full Bed Mesh
+gcode:
+  SET_PIN PIN=ADAPTIVE_BED_MESH VALUE=0
+  SET_PIN PIN=FULL_BED_MESH VALUE=0
+  RESPOND TYPE=command MSG="action:prompt_end"
+
+
+[gcode_macro _ADAPTIVE_PURGE_LINE_ON]
+description: Enable Adaptive Purge Line
+gcode:
+  SET_PIN PIN=ADAPTIVE_PURGE_LINE VALUE=1
+  RESPOND TYPE=command MSG="action:prompt_end"
+
+
+[gcode_macro _ADAPTIVE_PURGE_LINE_OFF]
+description: Disable Adaptive Purge Line
+gcode:
+  SET_PIN PIN=ADAPTIVE_PURGE_LINE VALUE=0
+  RESPOND TYPE=command MSG="action:prompt_end"
+
+
+[gcode_macro KAMP_BED_MESH_SETTINGS]
+description: Configure Bed Mesh type
+gcode:
+  RESPOND TYPE=command MSG="action:prompt_begin Bed Mesh Settings"
+  RESPOND TYPE=command MSG="action:prompt_text What type of bed mesh do you want to use when you start printing?"
+  RESPOND TYPE=command MSG="action:prompt_button ADAPTIVE BED MESH|_ADAPTIVE_BED_MESH_ON|primary"
+  RESPOND TYPE=command MSG="action:prompt_button FULL BED MESH|_FULL_BED_MESH_ON|primary"
+  RESPOND TYPE=command MSG="action:prompt_button NONE|_BED_MESH_OFF|primary"
+  RESPOND TYPE=command MSG="action:prompt_show"
+
+
+[gcode_macro KAMP_PURGE_LINE_SETTINGS]
+description: Configure Purge Line type
+gcode:
+  RESPOND TYPE=command MSG="action:prompt_begin Purge Line Settings"
+  RESPOND TYPE=command MSG="action:prompt_text What type of purge line do you want to use when you start printing?"
+  RESPOND TYPE=command MSG="action:prompt_button ADAPTIVE PURGE LINE|_ADAPTIVE_PURGE_LINE_ON|primary"
+  RESPOND TYPE=command MSG="action:prompt_button CLASSIC PURGE LINE|_ADAPTIVE_PURGE_LINE_OFF|primary"
+  RESPOND TYPE=command MSG="action:prompt_show"
+
+
+[gcode_macro START_PRINT]
+variable_prepare: 0
+gcode:
+  {% set bed_temp = printer.custom_macro.default_bed_temp %}
+  {% set extruder_temp = printer.custom_macro.default_extruder_temp %}
+  {% if 'BED_TEMP' in params|upper and (params.BED_TEMP|float) %}
+    {% set bed_temp = params.BED_TEMP %}
+  {% endif %}
+  {% if 'EXTRUDER_TEMP' in params|upper and (params.EXTRUDER_TEMP|float) %}
+    {% set extruder_temp = params.EXTRUDER_TEMP %}
+  {% endif %}
+
+  CLEAR_PAUSE
+  M140 S{bed_temp}                           ; Start bed heating without waiting
+  G28                                        ; Home all axes
+  M190 S{bed_temp}                           ; Wait for bed temp to stabilize
+
+  ; --- Bed mesh selection ---
+  {% if printer['output_pin ADAPTIVE_BED_MESH'].value == 1 %}
+    RESPOND TYPE=command MSG="Starting Adaptive Bed Mesh..."
+    BED_MESH_CLEAR
+    BED_MESH_CALIBRATE                       ; Call KAMP's bed mesh macro
+    BED_MESH_PROFILE SAVE=adaptive
+    BED_MESH_PROFILE LOAD=adaptive
+  {% elif printer['output_pin FULL_BED_MESH'].value == 1 %}
+    RESPOND TYPE=command MSG="Starting Full Bed Mesh..."
+    BED_MESH_CLEAR
+    _BED_MESH_CALIBRATE                      ; Call Klipper's default bed mesh macro
+    BED_MESH_PROFILE SAVE=default
+    BED_MESH_PROFILE LOAD=default
+  {% else %}
+    {% if printer['bed_mesh'].profile_name %}
+      RESPOND TYPE=command MSG="Loading existing bed mesh..."
+      BED_MESH_PROFILE LOAD=default
+    {% else %}
+      RESPOND TYPE=command MSG="No bed mesh found, running full calibration..."
+      BED_MESH_CLEAR
+      _BED_MESH_CALIBRATE                    ; Call Klipper's default bed mesh macro
+      BED_MESH_PROFILE SAVE=default
+      BED_MESH_PROFILE LOAD=default
+    {% endif %}
+  {% endif %}
+
+  ; --- Nozzle heat up ---
+  _SMART_PARK                                ; Park nozzle near print area
+  M109 S{extruder_temp}                      ; Wait for nozzle temp
+
+  ; --- Purge line selection ---
+  {% if printer['output_pin ADAPTIVE_PURGE_LINE'].value == 1 %}
+    RESPOND TYPE=command MSG="Starting Adaptive Purge Line..."  
+    _LINE_PURGE                              ; Call KAMP's line purge macro
+  {% else %}
+    RESPOND TYPE=command MSG="Starting Classic Purge Line..."
+    G92 E0                                   ; Reset extruder
+    G1 X-2.0 Y20 Z0.28 F5000.0               ; Move to start position
+    G1 X-2.0 Y145.0 Z0.28 F1500.0 E15        ; Draw first line
+    G1 X-2.6 Y145.0 Z0.28 F5000.0            ; Shift 0.6mm to the side
+    G1 X-2.6 Y20 Z0.28 F1500.0 E30           ; Draw second line
+    G92 E0                                   ; Reset extruder
+    G1 E-3.0 F1800                           ; Retract
+    G1 Z2.0 F3000                            ; Lift nozzle
+    G1 E0.0 F1800                            ; Un-retract to prime tip
+  {% endif %}
+
+  SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+  G92 E0                                     ; Reset extruder
+
+
+[gcode_macro END_PRINT]
+gcode:
+  {% set max_z = printer.toolhead.axis_maximum.z %}
+  {% set cur_z = printer.toolhead.position.z %}
+  {% set lift_z = [cur_z + 10, max_z] | min %}   ; Lift 10mm, don't exceed max Z
+
+  G91                                            ; Relative positioning
+  G1 E-2 F2700                                   ; Retract filament
+  G1 Z{lift_z - cur_z} F600                      ; Lift nozzle
+  G90                                            ; Absolute positioning
+  G1 X5 Y215 F5000                               ; Move nozzle aside, present bed
+  M104 S0                                        ; Turn off hotend
+  M140 S0                                        ; Turn off bed
+  M106 S0                                        ; Turn off part fan
+  M84                                            ; Disable motors

--- a/scripts/kamp.sh
+++ b/scripts/kamp.sh
@@ -7,11 +7,11 @@ function kamp_message(){
   title 'Klipper Adaptive Meshing & Purging' "${yellow}"
   inner_line
   hr
-  echo -e " │ ${cyan}KAMP is an extension that allows to generate a mesh and      ${white}│"
-  echo -e " │ ${cyan}purge line only in the area of the bed used by the objects   ${white}│"
-  echo -e " │ ${cyan}being printed. When used, the method will automatically      ${white}│"
-  echo -e " │ ${cyan}adjust the mesh parameters based on the area occupied by the ${white}│"
-  echo -e " │ ${cyan}defined print objects.                                       ${white}│"
+  echo -e " │ ${cyan}KAMP is an extension that allows to generate a mesh and        ${white}│"
+  echo -e " │ ${cyan}purge line only in the area of the bed used by the objects     ${white}│"
+  echo -e " │ ${cyan}being printed. When used, the method will automatically        ${white}│"
+  echo -e " │ ${cyan}adjust the mesh parameters based on the area occupied by the   ${white}│"
+  echo -e " │ ${cyan}defined print objects.                                         ${white}│"
   hr
   bottom_line
 }
@@ -42,6 +42,8 @@ function install_kamp(){
         ln -sf "$KAMP_URL"/Smart_Park.cfg "$KAMP_FOLDER"/Smart_Park.cfg
         if [ "$model" = "K1" ]; then
           ln -sf "$KAMP_URL"/Start_Print.cfg "$KAMP_FOLDER"/Start_Print.cfg
+        elif [ "$model" = "3KE" ]; then
+          ln -sf "$KAMP_URL"/Start_Print-3ke.cfg "$KAMP_FOLDER"/Start_Print.cfg
         else
           ln -sf "$KAMP_URL"/Start_Print-3v3.cfg "$KAMP_FOLDER"/Start_Print.cfg
         fi

--- a/scripts/menu/3KE/install_menu_3KE.sh
+++ b/scripts/menu/3KE/install_menu_3KE.sh
@@ -17,24 +17,25 @@ function install_menu_ui_3ke() {
   menu_option ' 5' 'Install' 'Klipper Gcode Shell Command'
   hr
   subtitle '•IMPROVEMENTS:'
-  menu_option ' 6' 'Install' 'Improved Shapers Calibrations'
-  menu_option ' 7' 'Install' 'Save Z-Offset Macros'
-  menu_option ' 8' 'Install' 'M600 Support'
-  menu_option ' 9' 'Install' 'Screws Tilt Adjust Support'
-  menu_option '10' 'Install' 'Git Backup'
+  menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
+  menu_option ' 7' 'Install' 'Improved Shapers Calibrations'
+  menu_option ' 8' 'Install' 'Save Z-Offset Macros'
+  menu_option ' 9' 'Install' 'M600 Support'
+  menu_option '10' 'Install' 'Screws Tilt Adjust Support'
+  menu_option '11' 'Install' 'Git Backup'
   hr
   subtitle '•CAMERA:'
-  menu_option '11' 'Install' 'Moonraker Timelapse'
-  menu_option '12' 'Install' 'Nebula Camera Settings Control'
-  menu_option '13' 'Install' 'USB Camera Support'
+  menu_option '12' 'Install' 'Moonraker Timelapse'
+  menu_option '13' 'Install' 'Nebula Camera Settings Control'
+  menu_option '14' 'Install' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '14' 'Install' 'OctoEverywhere'
-  menu_option '15' 'Install' 'Moonraker Obico'
-  menu_option '16' 'Install' 'GuppyFLO'
-  menu_option '17' 'Install' 'Mobileraker Companion'
-  menu_option '18' 'Install' 'OctoApp Companion'
-  menu_option '19' 'Install' 'SimplyPrint'
+  menu_option '15' 'Install' 'OctoEverywhere'
+  menu_option '16' 'Install' 'Moonraker Obico'
+  menu_option '17' 'Install' 'GuppyFLO'
+  menu_option '18' 'Install' 'Mobileraker Companion'
+  menu_option '19' 'Install' 'OctoApp Companion'
+  menu_option '20' 'Install' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -87,6 +88,12 @@ function install_menu_3ke() {
           run "install_gcode_shell_command" "install_menu_ui_3ke"
         fi;;
       6)
+        if [ -d "$KAMP_FOLDER" ]; then
+          error_msg "Klipper Adaptive Meshing & Purging is already installed!"
+        else
+          run "install_kamp" "install_menu_ui_3v3"
+        fi;;
+      7)
         if [ -d "$IMP_SHAPERS_FOLDER" ]; then
           error_msg "Improved Shapers Calibrations are already installed!"
         elif [ -d "$GUPPY_SCREEN_FOLDER" ]; then
@@ -96,25 +103,25 @@ function install_menu_3ke() {
         else
           run "install_improved_shapers" "install_menu_ui_3ke"
         fi;;
-      7)
+      8)
         if [ -f "$SAVE_ZOFFSET_FILE" ]; then
           error_msg "Save Z-Offset Macros are already installed!"
         else
           run "install_save_zoffset_macros" "install_menu_ui_3ke"
         fi;;
-      8)
+      9)
         if [ -f "$M600_SUPPORT_FILE" ]; then
           error_msg "M600 Support is already installed!"
         else
           run "install_m600_support" "install_menu_ui_3ke"
         fi;;
-      9)
+      10)
         if [ -f "$SCREWS_ADJUST_FILE" ]; then
           error_msg "Screws Tilt Adjust Support is already installed!"
         else
           run "install_screws_tilt_adjust" "install_menu_ui_3ke"
         fi;;
-      10)
+      11)
         if [ -f "$GIT_BACKUP_FILE" ]; then
           error_msg "Git Backup is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -124,7 +131,7 @@ function install_menu_3ke() {
         else
           run "install_git_backup" "install_menu_ui_3ke"
         fi;;
-      11)
+      12)
         if [ -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is already installed!"
         elif [ ! -f "$ENTWARE_FILE" ]; then
@@ -132,7 +139,7 @@ function install_menu_3ke() {
         else
           run "install_moonraker_timelapse" "install_menu_ui_3ke"
         fi;;
-      12)
+      13)
         if [ -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Nebula Camera Settings Control is already installed!"
         elif ! v4l2-ctl --list-devices | grep -q 'CCX2F3298'; then
@@ -142,7 +149,7 @@ function install_menu_3ke() {
         else
           run "install_camera_settings_control" "install_menu_ui_3ke"
         fi;;
-      13)
+      14)
         if [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Camera USB Support is already installed!"
         elif v4l2-ctl --list-devices | grep -qE 'CREALITY|CCX2F3298'; then
@@ -152,7 +159,7 @@ function install_menu_3ke() {
         else
           run "install_usb_camera" "install_menu_ui_3ke"
         fi;;
-      14)
+      15)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -162,7 +169,7 @@ function install_menu_3ke() {
         else
           run "install_octoeverywhere" "install_menu_ui_3ke"
         fi;;
-      15)
+      16)
         if [ ! -d "$MOONRAKER_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         elif [ ! -d "$FLUIDD_FOLDER" ] && [ ! -d "$MAINSAIL_FOLDER" ]; then
@@ -172,13 +179,13 @@ function install_menu_3ke() {
         else
           run "install_moonraker_obico" "install_menu_ui_3ke"
         fi;;
-      16)
+      17)
         if [ ! -d "$MOONRAKER_FOLDER" ] && [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_guppyflo" "install_menu_ui_3ke"
         fi;;
-      17)
+      18)
         if [ -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -190,7 +197,7 @@ function install_menu_3ke() {
         else
           run "install_mobileraker_companion" "install_menu_ui_3ke"
         fi;;
-      18)
+      19)
         if [ -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then
@@ -202,7 +209,7 @@ function install_menu_3ke() {
         else
           run "install_octoapp_companion" "install_menu_ui_3ke"
         fi;;
-      19)
+      20)
         if grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is already installed!"
         elif [ ! -d "$MOONRAKER_FOLDER" ]; then

--- a/scripts/menu/3KE/remove_menu_3KE.sh
+++ b/scripts/menu/3KE/remove_menu_3KE.sh
@@ -17,24 +17,25 @@ function remove_menu_ui_3ke() {
   menu_option ' 5' 'Remove' 'Klipper Gcode Shell Command'
   hr
   subtitle '•IMPROVEMENTS:'
-  menu_option ' 6' 'Remove' 'Improved Shapers Calibrations'
-  menu_option ' 7' 'Remove' 'Save Z-Offset Macros'
-  menu_option ' 8' 'Remove' 'M600 Support'
-  menu_option ' 9' 'Remove' 'Screws Tilt Adjust Support'
-  menu_option '10' 'Remove' 'Git Backup'
+  menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
+  menu_option ' 7' 'Remove' 'Improved Shapers Calibrations'
+  menu_option ' 8' 'Remove' 'Save Z-Offset Macros'
+  menu_option ' 9' 'Remove' 'M600 Support'
+  menu_option '10' 'Remove' 'Screws Tilt Adjust Support'
+  menu_option '11' 'Remove' 'Git Backup'
   hr
   subtitle '•CAMERA:'
-  menu_option '11' 'Remove' 'Moonraker Timelapse'
-  menu_option '12' 'Remove' 'Nebula Camera Settings Control'
-  menu_option '13' 'Remove' 'USB Camera Support'
+  menu_option '12' 'Remove' 'Moonraker Timelapse'
+  menu_option '13' 'Remove' 'Nebula Camera Settings Control'
+  menu_option '14' 'Remove' 'USB Camera Support'
   hr
   subtitle '•REMOTE ACCESS:'
-  menu_option '14' 'Remove' 'OctoEverywhere'
-  menu_option '15' 'Remove' 'Moonraker Obico'
-  menu_option '16' 'Remove' 'GuppyFLO'
-  menu_option '17' 'Remove' 'Mobileraker Companion'
-  menu_option '18' 'Remove' 'OctoApp Companion'
-  menu_option '19' 'Remove' 'SimplyPrint'
+  menu_option '15' 'Remove' 'OctoEverywhere'
+  menu_option '16' 'Remove' 'Moonraker Obico'
+  menu_option '17' 'Remove' 'GuppyFLO'
+  menu_option '18' 'Remove' 'Mobileraker Companion'
+  menu_option '19' 'Remove' 'OctoApp Companion'
+  menu_option '20' 'Remove' 'SimplyPrint'
   hr
   inner_line
   hr
@@ -109,84 +110,90 @@ function remove_menu_3ke() {
           run "remove_gcode_shell_command" "remove_menu_ui_3ke"
         fi;;
       6)
+        if [ ! -d "$KAMP_FOLDER" ]; then
+          error_msg "Klipper Adaptive Meshing & Purging is not installed!"
+        else
+          run "remove_kamp" "remove_menu_ui_3v3"
+        fi;;
+      7)
         if [ ! -d "$IMP_SHAPERS_FOLDER" ]; then
           error_msg "Improved Shapers Calibrations are not installed!"
         else
           run "remove_improved_shapers" "remove_menu_ui_3ke"
         fi;;
-      7)
+      8)
         if [ ! -f "$SAVE_ZOFFSET_FILE" ]; then
           error_msg "Save Z-Offset Macros are not installed!"
         else
           run "remove_save_zoffset_macros" "remove_menu_ui_3ke"
         fi;;
-      8)
+      9)
         if [ ! -f "$M600_SUPPORT_FILE" ]; then
           error_msg "M600 Support is not installed!"
         else
           run "remove_m600_support" "remove_menu_ui_3ke"
         fi;;
-      9)
+      10)
         if [ ! -f "$SCREWS_ADJUST_FILE" ]; then
           error_msg "Screws Tilt Adjust Support is not installed!"
         else
           run "remove_screws_tilt_adjust" "remove_menu_ui_3ke"
         fi;;
-      10)
+      11)
         if [ ! -f "$GIT_BACKUP_FILE" ]; then
           error_msg "Git Backup is not installed!"
         else
           run "remove_git_backup" "remove_menu_ui_3ke"
         fi;;
-      11)
+      12)
         if [ ! -f "$TIMELAPSE_FILE" ]; then
           error_msg "Moonraker Timelapse is not installed!"
         else
           run "remove_moonraker_timelapse" "remove_menu_ui_3ke"
         fi;;
-      12)
+      13)
         if [ ! -f "$CAMERA_SETTINGS_FILE" ]; then
           error_msg "Nebula Camera Settings Control is not installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_3ke"
         fi;;
-      13)
+      14)
         if [ ! -f "$USB_CAMERA_FILE" ]; then
           error_msg "USB Camera Support is not installed!"
         else
           run "remove_usb_camera" "remove_menu_ui_3ke"
         fi;;
-      14)
+      15)
         if [ ! -d "$OCTOEVERYWHERE_FOLDER" ]; then
           error_msg "OctoEverywhere is not installed!"
         else
           run "remove_octoeverywhere" "remove_menu_ui_3ke"
         fi;;
-      15)
+      16)
         if [ ! -d "$MOONRAKER_OBICO_FOLDER" ]; then
           error_msg "Moonraker Obico is not installed!"
         else
           run "remove_moonraker_obico" "remove_menu_ui_3ke"
         fi;;
-      16)
+      17)
         if [ ! -d "$GUPPYFLO_FOLDER" ]; then
           error_msg "GuppyFLO is not installed!"
         else
           run "remove_guppyflo" "remove_menu_ui_3ke"
         fi;;
-      17)
+      18)
         if [ ! -d "$MOBILERAKER_COMPANION_FOLDER" ]; then
           error_msg "Mobileraker Companion is not installed!"
         else
           run "remove_mobileraker_companion" "remove_menu_ui_3ke"
         fi;;
-      18)
+      19)
         if [ ! -d "$OCTOAPP_COMPANION_FOLDER" ]; then
           error_msg "OctoApp Companion is not installed!"
         else
           run "remove_octoapp_companion" "remove_menu_ui_3ke"
         fi;;
-      19)
+      20)
         if ! grep -q "\[simplyprint\]" "$MOONRAKER_CFG"; then
           error_msg "SimplyPrint is not installed!"
         else


### PR DESCRIPTION
# Background

KAMP (Klipper Adaptive Meshing & Purging) is currently not available for installation via Creality Helper Script for Ender-3 V3 KE printers. This PR adds KAMP for Ender-3 V3 KE.

# Changes

- Add KAMP item to install/remove menu
- Add 3KE-specific `START_PRINT` and `END_PRINT` g-code macros
- Add 3KE-specific classic purge line g-code (that's the way how I purged before; happy to change this if anyone has a better method for classical purging)
- Change default purge amount to 30mm, following the default value used in the official KAMP repo

# Tests

This PR has been tested on a Ender-3 V3 KE as follows:

- Orca slicer has been configured as defined in the wiki (especially start/end gcode): https://guilouz.github.io/Creality-Helper-Script-Wiki/slicers/orcaslicer/
- Classic purge line
- Adaptive purge line
- No bed mesh
- Full bed mesh
- Adaptive bed mesh